### PR TITLE
Fixed a NullReferenceException when synchronizing gmail

### DIFF
--- a/Wino.Core/Synchronizers/GmailSynchronizer.cs
+++ b/Wino.Core/Synchronizers/GmailSynchronizer.cs
@@ -904,9 +904,12 @@ namespace Wino.Core.Synchronizers
                 // Local copy doesn't exists. Continue execution to insert mail copy.
             }
 
-            foreach (var labelId in message.LabelIds)
+            if (message.LabelIds is not null)
             {
-                packageList.Add(new NewMailItemPackage(mailCopy, mimeMessage, labelId));
+                foreach (var labelId in message.LabelIds)
+                {
+                    packageList.Add(new NewMailItemPackage(mailCopy, mimeMessage, labelId));
+                }
             }
 
             return packageList;


### PR DESCRIPTION
I have an email that was crashing the app, due to `LabelIds` being null.

I don't know if `CreateNewMailPackagesAsync()` even needs to be called if `LabelIds` is null or empty.