### PR TITLE
Fixed NullReferenceException when replying to an email

### DIFF
--- a/Wino.Mail.ViewModels/Collections/WinoMailCollection.cs
+++ b/Wino.Mail.ViewModels/Collections/WinoMailCollection.cs
@@ -121,7 +121,7 @@ namespace Wino.Mail.ViewModels.Collections
 
                     var addedAccountProviderType = addedItem.AssignedAccount.ProviderType;
 
-                    var threadingStrategy = ThreadingStrategyProvider.GetStrategy(addedAccountProviderType);
+                    var threadingStrategy = ThreadingStrategyProvider?.GetStrategy(addedAccountProviderType);
 
                     if (threadingStrategy?.ShouldThreadWithItem(addedItem, item) ?? false)
                     {


### PR DESCRIPTION
ThreadingStrategyProvider is null when conversation threading is disabled.