### PR TITLE
Fix commend bar issues 

### DIFF
--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -462,7 +462,7 @@ namespace Wino.Mail.ViewModels
             MenuItems.Clear();
 
             // Add light/dark editor theme switch.
-            if (_underlyingThemeService.IsUnderlyingThemeDark())
+            if (IsDarkWebviewRenderer)
                 MenuItems.Add(MailOperationMenuItem.Create(MailOperation.LightEditor));
             else
                 MenuItems.Add(MailOperationMenuItem.Create(MailOperation.DarkEditor));

--- a/Wino.Mail/Behaviors/BindableCommandBarBehavior.cs
+++ b/Wino.Mail/Behaviors/BindableCommandBarBehavior.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Xaml.Interactivity;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Specialized;
 using System.Windows.Input;
+using Microsoft.Xaml.Interactivity;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -98,42 +98,37 @@ namespace Wino.Behaviors
             {
                 if (command is MailOperationMenuItem mailOperationMenuItem)
                 {
+                    ICommandBarElement menuItem = null;
+
                     if (mailOperationMenuItem.Operation == Core.Domain.Enums.MailOperation.Seperator)
                     {
-                        var seperator = new AppBarSeparator();
-
-                        if (mailOperationMenuItem.IsSecondaryMenuPreferred)
-                        {
-                            AssociatedObject.SecondaryCommands.Add(seperator);
-                        }
-                        else
-                        {
-                            AssociatedObject.PrimaryCommands.Add(seperator);
-                        }
+                        menuItem = new AppBarSeparator();
                     }
                     else
                     {
-                        var menuItem = new AppBarButton()
+                        var label = XamlHelpers.GetOperationString(mailOperationMenuItem.Operation);
+                        menuItem = new AppBarButton
                         {
                             Icon = new WinoFontIcon() { Glyph = ControlConstants.WinoIconFontDictionary[XamlHelpers.GetWinoIconGlyph(mailOperationMenuItem.Operation)] },
-                            Label = XamlHelpers.GetOperationString(mailOperationMenuItem.Operation),
+                            Label = label,
+                            LabelPosition = string.IsNullOrWhiteSpace(label) ? CommandBarLabelPosition.Collapsed : CommandBarLabelPosition.Default,
                             DataContext = mailOperationMenuItem,
                         };
 
-                        menuItem.Click -= Button_Click;
-                        menuItem.Click += Button_Click;
+                        ((AppBarButton)menuItem).Click -= Button_Click;
+                        ((AppBarButton)menuItem).Click += Button_Click;
+                    }
 
-                        if (mailOperationMenuItem.IsSecondaryMenuPreferred)
-                        {
-                            AssociatedObject.SecondaryCommands.Add(menuItem);
-                        }
-                        else
-                        {
-                            AssociatedObject.PrimaryCommands.Add(menuItem);
-                        }
+                    if (mailOperationMenuItem.IsSecondaryMenuPreferred)
+                    {
+                        AssociatedObject.SecondaryCommands.Add(menuItem);
+                    }
+                    else
+                    {
+                        AssociatedObject.PrimaryCommands.Add(menuItem);
                     }
                 }
-                
+
                 //if (dependencyObject is ICommandBarElement icommandBarElement)
                 //{
                 //    if (dependencyObject is ButtonBase button)
@@ -144,7 +139,7 @@ namespace Wino.Behaviors
 
                 //    if (command is MailOperationMenuItem mailOperationMenuItem)
                 //    {
-                        
+
                 //    }
                 //}
             }

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -150,12 +150,10 @@
             x:Name="RendererBar"
             Grid.Row="0"
             Margin="8,6,0,0"
-            IsSticky="True"
+            IsSticky="False"
             DefaultLabelPosition="Right"
             HorizontalContentAlignment="Stretch"
-            OverflowButtonVisibility="Auto"
-            DynamicOverflowItemsChanging="BarDynamicOverflowChanging"
-            IsDynamicOverflowEnabled="True">
+            OverflowButtonVisibility="Auto">
             <interactivity:Interaction.Behaviors>
                 <local:BindableCommandBarBehavior
                     ItemClickedCommand="{x:Bind ViewModel.OperationClickedCommand}"

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -150,10 +150,11 @@
             x:Name="RendererBar"
             Grid.Row="0"
             Margin="8,6,0,0"
-            IsSticky="False"
             DefaultLabelPosition="Right"
             HorizontalContentAlignment="Stretch"
-            OverflowButtonVisibility="Auto">
+            OverflowButtonVisibility="Auto"
+            DynamicOverflowItemsChanging="BarDynamicOverflowChanging"
+            IsDynamicOverflowEnabled="True">
             <interactivity:Interaction.Behaviors>
                 <local:BindableCommandBarBehavior
                     ItemClickedCommand="{x:Bind ViewModel.OperationClickedCommand}"

--- a/Wino.Mail/Views/MailRenderingPage.xaml.cs
+++ b/Wino.Mail/Views/MailRenderingPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.AppCenter.Crashes;
@@ -218,7 +219,7 @@ namespace Wino.Views
 
         private void BarDynamicOverflowChanging(CommandBar sender, DynamicOverflowItemsChangingEventArgs args)
         {
-            if (args.Action == CommandBarDynamicOverflowAction.AddingToOverflow)
+            if (args.Action == CommandBarDynamicOverflowAction.AddingToOverflow || sender.SecondaryCommands.Any())
                 sender.OverflowButtonVisibility = CommandBarOverflowButtonVisibility.Visible;
             else
                 sender.OverflowButtonVisibility = CommandBarOverflowButtonVisibility.Collapsed;


### PR DESCRIPTION
Fixed #165

> 1. is not really a bug because only most commonly used items must be in Primary, rest should not fill up the UI. Therefore 'Save As' belongs to Secondary commands. Also, just secondary commands are designed to be hidden even if there are space in CommandBar.

Yeah, I understand that save as should be hidden. But I guess "three dots" button should be visible all the time, right? Otherwise it will not be possible to click "Save As" without making a window smaller to trigger three dots.