### PR TITLE
Improve performance of API Threading strategy.

### DIFF
--- a/Wino.Core.Domain/Interfaces/IThreadingStrategy.cs
+++ b/Wino.Core.Domain/Interfaces/IThreadingStrategy.cs
@@ -7,6 +7,11 @@ namespace Wino.Core.Domain.Interfaces
 {
     public interface IThreadingStrategy
     {
+        /// <summary>
+        /// Attach thread mails to the list.
+        /// </summary>
+        /// <param name="items">Original mails.</param>
+        /// <returns>Original mails with thread mails.</returns>
         Task<List<IMailItem>> ThreadItemsAsync(List<MailCopy> items);
         bool ShouldThreadWithItem(IMailItem originalItem, IMailItem targetItem);
     }

--- a/Wino.Core/Integration/Threading/APIThreadingStrategy.cs
+++ b/Wino.Core/Integration/Threading/APIThreadingStrategy.cs
@@ -53,7 +53,6 @@ namespace Wino.Core.Integration.Threading
                 var threadItems = (await GetThreadItemsAsync(potentiallyThreadedMails.Select(x => (x.ThreadId, x.AssignedFolder)).ToList(), assignedAccount.Id, sentFolder.Id, draftFolder.Id))
                 .GroupBy(x => x.ThreadId);
 
-                var folderCache = new Dictionary<Guid, MailItemFolder>();
                 foreach (var threadItem in threadItems)
                 {
                     if (threadItem.Count() == 1)

--- a/Wino.Core/Services/MailService.cs
+++ b/Wino.Core/Services/MailService.cs
@@ -195,7 +195,7 @@ namespace Wino.Core.Services
             // Avoid DBs calls as possible, storing info in a dictionary.
             foreach (var mail in mails)
             {
-                await PopulateFolderAndAccountAssignment(mail, folderCache, accountCache).ConfigureAwait(false);
+                await LoadAssignedPropertiesWithCacheAsync(mail, folderCache, accountCache).ConfigureAwait(false);
             }
 
             // Remove items that has no assigned account or folder.
@@ -229,7 +229,7 @@ namespace Wino.Core.Services
                 // Almost everything already should be in cache from initial population.
                 foreach (var mail in accountThreadedItems)
                 {
-                    await PopulateFolderAndAccountAssignment(mail, folderCache, accountCache).ConfigureAwait(false);
+                    await LoadAssignedPropertiesWithCacheAsync(mail, folderCache, accountCache).ConfigureAwait(false);
                 }
 
                 if (accountThreadedItems != null)
@@ -243,13 +243,13 @@ namespace Wino.Core.Services
             return threadedItems;
 
             // Recursive function to populate folder and account assignments for each mail item.
-            async Task PopulateFolderAndAccountAssignment(IMailItem mail, Dictionary<Guid, MailItemFolder> folderCache, Dictionary<Guid, MailAccount> accountCache)
+            async Task LoadAssignedPropertiesWithCacheAsync(IMailItem mail, Dictionary<Guid, MailItemFolder> folderCache, Dictionary<Guid, MailAccount> accountCache)
             {
                 if (mail is ThreadMailItem threadMailItem)
                 {
                     foreach (var childMail in threadMailItem.ThreadItems)
                     {
-                        await PopulateFolderAndAccountAssignment(childMail, folderCache, accountCache).ConfigureAwait(false);
+                        await LoadAssignedPropertiesWithCacheAsync(childMail, folderCache, accountCache).ConfigureAwait(false);
                     }
                 }
 


### PR DESCRIPTION
Fixes #172 
Changes: 
1) Instead of query for each mail to get thread related mails, it sends one query for all emails of particular account. 
2) Folder and account assgiments now cached in a dictionary to reduce number of calls to DB. 

I did some performance measurements. They are not perfect since were done in a debug mode and just with stopwatch, but anyway they are much better. For measurements I opened wino (initial load of emails for first account) and scrolled to load more items 5 times. Then switched account to second and repeated: 

### Before

| Account         | Iteration 1 | Iteration 2 | Iteration 3 | Iteration 4 | Iteration 5 | Iteration 6 |
|-----------------|-------------|-------------|-------------|-------------|-------------|-------------|
| First Account  | 6.34        | 8.4         | 7.61        | 7.49        | 6.56        | 7.12        |
| Second Account | 8.04        | 6.17        | 5.62        | 7.31        | 6.33        | 6.14        |

### After

| Account         | Iteration 1 | Iteration 2 | Iteration 3 | Iteration 4 | Iteration 5 | Iteration 6 |
|-----------------|-------------|-------------|-------------|-------------|-------------|-------------|
| First Account  | 1.3         | 0.87        | 0.52        | 0.56        | 0.68        | 0.45        |
| Second Account | 0.59        | 0.37        | 0.55        | 0.46        | 0.48        | 0.57        |



