### PR TITLE
Fixed scrollbars in a dark theme to be accessible

### DIFF
--- a/Wino.Mail/JS/Quill/full.html
+++ b/Wino.Mail/JS/Quill/full.html
@@ -5,14 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="language" content="english">
     <meta name="viewport" content="width=device-width">
-
     <link rel="stylesheet" href="https://app.example/katex.min.css" />
-
     <link rel="stylesheet" href="https://app.example/monokai-sublime.min.css" />
-
     <link rel="stylesheet" href="https://app.example/quill.snow.css" />
+    <link rel="stylesheet" href="https://app.example/global.css" />
 
-    <style>
+     <style>
         body >
         /* #standalone-container {
             margin: 50px auto;
@@ -30,6 +28,7 @@
     </style>
 </head>
 <body>
+    <meta name="color-scheme" content="dark light">
     <div id="standalone-container">
         <!-- remove display none to enable toolbar -->
         <div id="toolbar-container" style="display: none;">
@@ -242,22 +241,22 @@
             return quill.getText();
         }
 
-        function SetLightEditor()
-        {
+        function SetLightEditor(){
+            document.documentElement.setAttribute('data-theme', 'light');
             DarkReader.disable();
         }
 
-        function SetDarkEditor()
-        {
+        function SetDarkEditor(){
+            document.documentElement.setAttribute('data-theme', 'dark');
             DarkReader.enable();
         }
 
-        // function ShowToolbar() {
-        //     document.getElementById('editor-container').style.display = 'block';
+                // function ShowToolbar() {
+                //     document.getElementById('editor-container').style.display = 'block';
         //     quill.focus();
         // }
 
-        // function HideToolbar() {
+                // function HideToolbar() {
         //     document.getElementById('editor-container').style.display = 'none';
         // }
 

--- a/Wino.Mail/JS/Quill/full.html
+++ b/Wino.Mail/JS/Quill/full.html
@@ -242,12 +242,10 @@
         }
 
         function SetLightEditor(){
-            document.documentElement.setAttribute('data-theme', 'light');
             DarkReader.disable();
         }
 
         function SetDarkEditor(){
-            document.documentElement.setAttribute('data-theme', 'dark');
             DarkReader.enable();
         }
 

--- a/Wino.Mail/JS/Quill/global.css
+++ b/Wino.Mail/JS/Quill/global.css
@@ -1,0 +1,4 @@
+* {
+    scrollbar-color: auto !important;
+    scrollbar-width: thin !important;
+}

--- a/Wino.Mail/JS/Quill/reader.html
+++ b/Wino.Mail/JS/Quill/reader.html
@@ -1,39 +1,38 @@
 <html>
-    <body style="padding-left:12px; padding-right:12px; padding-top:8px; padding-bottom: 8px; margin: 0px; border-radius: 8px;">
-        <meta name="color-scheme" content="dark light">
-        <script src="https://app.reader/darkreader.js"></script>
+<body style="padding-left:12px; padding-right:12px; padding-top:8px; padding-bottom: 8px; margin: 0px; border-radius: 8px;">
+    <meta name="color-scheme" content="dark light">
+    <script src="https://app.reader/darkreader.js"></script>
 
-        <script>
-            function RenderHTML(htmlString) {
-                var containerDiv = document.getElementById("readerDiv");
-                containerDiv.innerHTML = htmlString;
-            }
+    <script>
+        function RenderHTML(htmlString) {
+            var containerDiv = document.getElementById("readerDiv");
+            containerDiv.innerHTML = htmlString;
+        }
 
-            function ChangeFontFamily(fontFamily) {
-                var containerDiv = document.getElementById("readerDiv");
-                containerDiv.style.fontFamily = fontFamily;
-            }
+        function ChangeFontFamily(fontFamily) {
+            var containerDiv = document.getElementById("readerDiv");
+            containerDiv.style.fontFamily = fontFamily;
+        }
 
-            function ChangeFontSize(size) {
-                var containerDiv = document.getElementById("readerDiv");
-                containerDiv.style.fontSize = size;
-            }
+        function ChangeFontSize(size) {
+            var containerDiv = document.getElementById("readerDiv");
+            containerDiv.style.fontSize = size;
+        }
 
-            function SetLightEditor() {
-                document.documentElement.setAttribute('data-theme', 'light');
-                DarkReader.disable();
-            }
+        function SetLightEditor() {
+            document.documentElement.setAttribute('data-theme', 'light');
+            DarkReader.disable();
+        }
 
-            function SetDarkEditor() {
-                document.documentElement.setAttribute('data-theme', 'dark');
-                DarkReader.enable();
-            }
-        </script>
+        function SetDarkEditor() {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            DarkReader.enable();
+        }
+    </script>
 
-        <link rel="stylesheet" href="https://app.reader/reader.css" />
-        <link rel="stylesheet" href="https://app.reader/global.css" />
-
-        <div id="readerDiv">
-        </div>
-    </body>
+    <link rel="stylesheet" href="https://app.reader/reader.css" />
+    <div id="readerDiv">
+    </div>
+    <link rel="stylesheet" href="https://app.reader/global.css" />
+</body>
 </html>

--- a/Wino.Mail/JS/Quill/reader.html
+++ b/Wino.Mail/JS/Quill/reader.html
@@ -19,12 +19,19 @@
                 containerDiv.style.fontSize = size;
             }
 
-            function ChangePrefferedTheme(theme) {
-                document.documentElement.setAttribute('data-theme', theme);
+            function SetLightEditor() {
+                document.documentElement.setAttribute('data-theme', 'light');
+                DarkReader.disable();
+            }
+
+            function SetDarkEditor() {
+                document.documentElement.setAttribute('data-theme', 'dark');
+                DarkReader.enable();
             }
         </script>
 
         <link rel="stylesheet" href="https://app.reader/reader.css" />
+        <link rel="stylesheet" href="https://app.reader/global.css" />
 
         <div id="readerDiv">
         </div>

--- a/Wino.Mail/Views/ComposePage.xaml.cs
+++ b/Wino.Mail/Views/ComposePage.xaml.cs
@@ -56,6 +56,7 @@ namespace Wino.Views
             InitializeComponent();
 
             Environment.SetEnvironmentVariable("WEBVIEW2_DEFAULT_BACKGROUND_COLOR", "00FFFFFF");
+            Environment.SetEnvironmentVariable("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", "--enable-features=OverlayScrollbar,OverlayScrollbarWinStyle,OverlayScrollbarWinStyleAnimation");
         }
 
         private static async void OnIsComposerDarkModeChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)

--- a/Wino.Mail/Views/ComposePage.xaml.cs
+++ b/Wino.Mail/Views/ComposePage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
@@ -21,9 +20,9 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
-using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Entities;
 using Wino.Core.Domain.Enums;
+using Wino.Core.Domain.Interfaces;
 using Wino.Core.Messages.Mails;
 using Wino.Core.Messages.Shell;
 using Wino.Extensions;
@@ -261,11 +260,13 @@ namespace Wino.Views
 
             if (IsComposerDarkMode)
             {
-                await InvokeScriptSafeAsync("DarkReader.enable();");
+                Chromium.CoreWebView2.Profile.PreferredColorScheme = CoreWebView2PreferredColorScheme.Dark;
+                await InvokeScriptSafeAsync("SetDarkEditor();");
             }
             else
             {
-                await InvokeScriptSafeAsync("DarkReader.disable();");
+                Chromium.CoreWebView2.Profile.PreferredColorScheme = CoreWebView2PreferredColorScheme.Light;
+                await InvokeScriptSafeAsync("SetLightEditor();");
             }
         }
 

--- a/Wino.Mail/Views/MailRenderingPage.xaml.cs
+++ b/Wino.Mail/Views/MailRenderingPage.xaml.cs
@@ -233,15 +233,13 @@ namespace Wino.Views
             {
                 Chromium.CoreWebView2.Profile.PreferredColorScheme = CoreWebView2PreferredColorScheme.Dark;
 
-                await InvokeScriptSafeAsync("ChangePrefferedTheme('dark')");
-                await InvokeScriptSafeAsync("DarkReader.enable();");
+                await InvokeScriptSafeAsync("SetDarkEditor();");
             }
             else
             {
                 Chromium.CoreWebView2.Profile.PreferredColorScheme = CoreWebView2PreferredColorScheme.Light;
 
-                await InvokeScriptSafeAsync("ChangePrefferedTheme('light')");
-                await InvokeScriptSafeAsync("DarkReader.disable();");
+                await InvokeScriptSafeAsync("SetLightEditor();");
             }
         }
 

--- a/Wino.Mail/Views/MailRenderingPage.xaml.cs
+++ b/Wino.Mail/Views/MailRenderingPage.xaml.cs
@@ -42,7 +42,7 @@ namespace Wino.Views
             InitializeComponent();
 
             Environment.SetEnvironmentVariable("WEBVIEW2_DEFAULT_BACKGROUND_COLOR", "00FFFFFF");
-
+            Environment.SetEnvironmentVariable("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", "--enable-features=OverlayScrollbar,OverlayScrollbarWinStyle,OverlayScrollbarWinStyleAnimation");
             NavigationCacheMode = NavigationCacheMode.Enabled;
         }
 

--- a/Wino.Mail/Views/Settings/SignatureManagementPage.xaml.cs
+++ b/Wino.Mail/Views/Settings/SignatureManagementPage.xaml.cs
@@ -31,6 +31,7 @@ namespace Wino.Views.Settings
             this.InitializeComponent();
 
             // Environment.SetEnvironmentVariable("WEBVIEW2_DEFAULT_BACKGROUND_COLOR", "00FFFFFF");
+            Environment.SetEnvironmentVariable("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", "--enable-features=OverlayScrollbar,OverlayScrollbarWinStyle,OverlayScrollbarWinStyleAnimation");
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/Wino.Mail/Wino.Mail.csproj
+++ b/Wino.Mail/Wino.Mail.csproj
@@ -755,6 +755,7 @@
     <Content Include="BackgroundImages\Snowflake.jpg" />
     <Content Include="JS\Quill\darkreader.js" />
     <Content Include="JS\Quill\full.html" />
+    <Content Include="JS\Quill\global.css" />
     <Content Include="JS\Quill\highlight.min.js" />
     <Content Include="JS\Quill\image-resize.min.js" />
     <Content Include="JS\Quill\katex.min.css" />


### PR DESCRIPTION
Fixes #106 

Changed: 
1) Added global.css file that included in both reader and full htmls. It sets styles with !important to override css that dark reader automatically generates. 
2) set env variables for webview2 to style them like windows native scrollbars. 

Result: 
Default: 
![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/44190764-b106-445f-b908-0083020115c8)

Hovered: 
![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/aeb4d92b-d1a7-4d6b-a394-70d63823e44a)

Light mode hovered: 
![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/9b193b7d-f4a8-4f28-9b63-191f686f5488)
