### PR TITLE
Improved attachments UI and added filter option "Has files"

### DIFF
--- a/Wino.Core.Domain/Enums/FilterOptionType.cs
+++ b/Wino.Core.Domain/Enums/FilterOptionType.cs
@@ -5,6 +5,7 @@
         All,
         Unread,
         Flagged,
-        Mentions
+        Mentions,
+        Files
     }
 }

--- a/Wino.Core.Domain/Translations/en_US/resources.json
+++ b/Wino.Core.Domain/Translations/en_US/resources.json
@@ -121,6 +121,7 @@
     "FilteringOption_All": "All",
     "FilteringOption_Flagged": "Flagged",
     "FilteringOption_Unread": "Unread",
+    "FilteringOption_Files": "Has files",
     "Focused": "Focused",
     "FolderOperation_CreateSubFolder": "Create sub folder",
     "FolderOperation_Delete": "Delete",

--- a/Wino.Core.Domain/Translator.Designer.cs
+++ b/Wino.Core.Domain/Translator.Designer.cs
@@ -629,6 +629,11 @@ namespace Wino.Core.Domain
 		public static string FilteringOption_Unread => Resources.GetTranslatedString(@"FilteringOption_Unread");	
 	
         /// <summary>
+		/// Has files
+		/// </summary>
+		public static string FilteringOption_Files => Resources.GetTranslatedString(@"FilteringOption_Files");	
+	
+        /// <summary>
 		/// Focused
 		/// </summary>
 		public static string Focused => Resources.GetTranslatedString(@"Focused");	

--- a/Wino.Core/Services/MailService.cs
+++ b/Wino.Core/Services/MailService.cs
@@ -156,6 +156,9 @@ namespace Wino.Core.Services
                 case FilterOptionType.Flagged:
                     query.Where("MailCopy.IsFlagged", true);
                     break;
+                case FilterOptionType.Files:
+                    query.Where("MailCopy.HasAttachments", true);
+                    break;
             }
 
             if (options.IsFocusedOnly != null)

--- a/Wino.Mail.ViewModels/MailListPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailListPageViewModel.cs
@@ -88,7 +88,8 @@ namespace Wino.Mail.ViewModels
         [
             new (Translator.FilteringOption_All, FilterOptionType.All),
             new (Translator.FilteringOption_Unread, FilterOptionType.Unread),
-            new (Translator.FilteringOption_Flagged, FilterOptionType.Flagged)
+            new (Translator.FilteringOption_Flagged, FilterOptionType.Flagged),
+            new (Translator.FilteringOption_Files, FilterOptionType.Files)
         ];
 
         private FolderPivotViewModel _selectedFolderPivot;
@@ -510,14 +511,12 @@ namespace Wino.Mail.ViewModels
 
         private bool ShouldPreventItemAdd(IMailItem mailItem)
         {
-            bool condition2 = false;
-
-            bool condition1 = mailItem.IsRead
+            bool condition = mailItem.IsRead
                               && SelectedFilterOption.Type == FilterOptionType.Unread
                               || !mailItem.IsFlagged
                               && SelectedFilterOption.Type == FilterOptionType.Flagged;
 
-            return condition1 || condition2;
+            return condition;
         }
 
         protected override async void OnMailAdded(MailCopy addedMail)
@@ -546,7 +545,7 @@ namespace Wino.Mail.ViewModels
                     NotifyItemFoundState();
                 });
             }
-            catch (Exception) { }
+            catch { }
             finally
             {
                 listManipulationSemepahore.Release();

--- a/Wino.Mail/Extensions/MimeKitExtensions.cs
+++ b/Wino.Mail/Extensions/MimeKitExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.Helpers;
 using Windows.Storage;
 using Wino.Mail.ViewModels.Data;
 
@@ -11,7 +12,7 @@ namespace Wino.Extensions
         {
             if (storageFile == null) return null;
 
-            var bytes = await File.ReadAllBytesAsync(storageFile.Name);
+            var bytes = await storageFile.ReadBytesAsync();
 
             return new MailAttachmentViewModel(storageFile.Name, bytes);
         }

--- a/Wino.Mail/Helpers/XamlHelpers.cs
+++ b/Wino.Mail/Helpers/XamlHelpers.cs
@@ -108,22 +108,16 @@ namespace Wino.Helpers
 
         #region Wino Font Icon Transformation
 
-        public static WinoIconGlyph GetWinoIconGlyph(FilterOptionType type)
+        public static WinoIconGlyph GetWinoIconGlyph(FilterOptionType type) => type switch
         {
-            switch (type)
-            {
-                case FilterOptionType.All:
-                    return WinoIconGlyph.SpecialFolderCategory;
-                case FilterOptionType.Unread:
-                    return WinoIconGlyph.MarkUnread;
-                case FilterOptionType.Flagged:
-                    return WinoIconGlyph.Flag;
-                case FilterOptionType.Mentions:
-                    return WinoIconGlyph.NewMail;
-                default:
-                    return WinoIconGlyph.None;
-            }
-        }
+            FilterOptionType.All => WinoIconGlyph.SpecialFolderCategory,
+            FilterOptionType.Unread => WinoIconGlyph.MarkUnread,
+            FilterOptionType.Flagged => WinoIconGlyph.Flag,
+            FilterOptionType.Mentions => WinoIconGlyph.NewMail,
+            // TODO: Attachments icon should be added to WinoIcons.ttf.
+            FilterOptionType.Files => WinoIconGlyph.None,
+            _ => WinoIconGlyph.None,
+        };
 
         public static WinoIconGlyph GetWinoIconGlyph(MailOperation operation)
         {

--- a/Wino.Mail/Views/ComposePage.xaml
+++ b/Wino.Mail/Views/ComposePage.xaml
@@ -54,11 +54,14 @@
         </DataTemplate>
 
         <!--  Attachment Template  -->
+        <!--  Margin -8 0 is used to remove the padding from the ListViewItem-->
         <DataTemplate x:Key="ComposerFileAttachmentTemplate" x:DataType="data:MailAttachmentViewModel">
             <Grid
-                Height="75"
+                Height="50"
                 Background="Transparent"
-                ColumnSpacing="3">
+                ColumnSpacing="3"
+                Margin="-8 0"
+                Padding="0,0,5,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="36" />
                     <ColumnDefinition Width="*" />
@@ -74,7 +77,7 @@
                 <!--  Name && Size  -->
                 <Grid
                     Grid.Column="1"
-                    MaxWidth="250"
+                    MaxWidth="200"
                     VerticalAlignment="Center">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -85,7 +88,7 @@
                         FontSize="13"
                         Text="{x:Bind FileName}"
                         MaxLines="2"
-                        TextTrimming="None" />
+                        TextTrimming="CharacterEllipsis" />
 
                     <TextBlock
                         Grid.Row="1"
@@ -98,7 +101,7 @@
 
                 <SymbolIcon
                     Grid.Column="2"
-                    Margin="6,0"
+                    Margin="0,0,0,0"
                     VerticalAlignment="Center"
                     Symbol="Cancel"
                     Foreground="{StaticResource DeleteBrush}" />
@@ -602,24 +605,25 @@
                 Text="{x:Bind ViewModel.Subject, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
             <!--  Attachments  -->
-            <ListView
-                x:Name="AttachmentsListView"
-                Grid.Row="6"
-                Grid.ColumnSpan="2"
-                x:Load="{x:Bind helpers:XamlHelpers.CountToBooleanConverter(ViewModel.IncludedAttachments.Count), Mode=OneWay}"
-                IsItemClickEnabled="True"
-                ItemTemplate="{StaticResource ComposerFileAttachmentTemplate}"
-                ItemsSource="{x:Bind ViewModel.IncludedAttachments, Mode=OneWay}"
-                ScrollViewer.VerticalScrollBarVisibility="Visible"
-                ScrollViewer.VerticalScrollMode="Enabled"
-                ItemClick="AttachmentClicked"
-                SelectionMode="None">
+            <ListView x:Name="AttachmentsListView"
+                  Grid.Row="6"
+                  Padding="5"
+                  Grid.ColumnSpan="2"
+                  x:Load="{x:Bind helpers:XamlHelpers.CountToBooleanConverter(ViewModel.IncludedAttachments.Count), Mode=OneWay}"
+                  IsItemClickEnabled="True"
+                  ItemTemplate="{StaticResource ComposerFileAttachmentTemplate}"
+                  ItemsSource="{x:Bind ViewModel.IncludedAttachments, Mode=OneWay}"
+                  ItemClick="AttachmentClicked"
+                  SelectionMode="None">
                 <ListView.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <ItemsStackPanel Orientation="Horizontal" />
+                        <controls1:WrapPanel Orientation="Horizontal" />
                     </ItemsPanelTemplate>
                 </ListView.ItemsPanel>
             </ListView>
+
+            <!--Attachments-->
+            
         </Grid>
 
         <Grid

--- a/Wino.Mail/Views/ComposePage.xaml
+++ b/Wino.Mail/Views/ComposePage.xaml
@@ -60,8 +60,7 @@
                 Height="50"
                 Background="Transparent"
                 ColumnSpacing="3"
-                Margin="-8 0"
-                Padding="0,0,5,0">
+                Margin="-8,0,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="36" />
                     <ColumnDefinition Width="*" />
@@ -101,7 +100,6 @@
 
                 <SymbolIcon
                     Grid.Column="2"
-                    Margin="0,0,0,0"
                     VerticalAlignment="Center"
                     Symbol="Cancel"
                     Foreground="{StaticResource DeleteBrush}" />
@@ -607,7 +605,6 @@
             <!--  Attachments  -->
             <ListView x:Name="AttachmentsListView"
                   Grid.Row="6"
-                  Padding="5"
                   Grid.ColumnSpan="2"
                   x:Load="{x:Bind helpers:XamlHelpers.CountToBooleanConverter(ViewModel.IncludedAttachments.Count), Mode=OneWay}"
                   IsItemClickEnabled="True"

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -111,7 +111,8 @@
                     <!--  Name && Size  -->
                     <Grid Grid.Column="1"
                           VerticalAlignment="Center"
-                          Padding="0,0,5,0">
+                          Padding="0,0,5,0"
+                          MaxWidth="200">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:controls2="using:CommunityToolkit.WinUI.Controls"
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
     xmlns:selectors="using:Wino.Selectors"
     IsDarkEditor="{x:Bind ViewModel.IsDarkWebviewRenderer, Mode=TwoWay}"
@@ -59,75 +60,92 @@
             ReplyAll="{StaticResource CommandBarItemReplyAllTemplate}" />
 
         <!--  Attachment Template  -->
+        <!--  Margin -8 0 is used to remove the padding from the ListViewItem-->
         <DataTemplate x:Key="FileAttachmentTemplate" x:DataType="viewModelData:MailAttachmentViewModel">
-            <Grid
-                Height="75"
-                Background="Transparent"
-                ColumnSpacing="3">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="{x:Bind FileName}" />
-                </ToolTipService.ToolTip>
-                <Grid.ContextFlyout>
-                    <MenuFlyout Placement="Right">
-                        <MenuFlyoutItem
-                            Text="{x:Bind domain:Translator.Buttons_Open}"
-                            Command="{Binding ElementName=root, Path=ViewModel.OpenAttachmentCommand}"
-                            CommandParameter="{x:Bind}">
-                            <MenuFlyoutItem.Icon>
-                                <PathIcon Data="{StaticResource OpenFilePathIcon}" />
-                            </MenuFlyoutItem.Icon>
-                        </MenuFlyoutItem>
-                        <MenuFlyoutItem
-                            Text="{x:Bind domain:Translator.Buttons_Save}"
-                            Command="{Binding ElementName=root, Path=ViewModel.SaveAttachmentCommand}"
-                            CommandParameter="{x:Bind}">
-                            <MenuFlyoutItem.Icon>
-                                <PathIcon Data="{StaticResource SaveAttachmentPathIcon}" />
-                            </MenuFlyoutItem.Icon>
-                        </MenuFlyoutItem>
-                    </MenuFlyout>
-                </Grid.ContextFlyout>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="36" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
+            <Grid Height="51" RowSpacing="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="50" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <Grid
+                    Grid.Row="0"
+                    Height="50"
+                    Background="Transparent"
+                    ColumnSpacing="3"
+                    Padding="0,0,5,0"
+                    Margin="-8 0">
+                    <ToolTipService.ToolTip>
+                        <ToolTip Content="{x:Bind FileName}" />
+                    </ToolTipService.ToolTip>
+                    <Grid.ContextFlyout>
+                        <MenuFlyout Placement="Right">
+                            <MenuFlyoutItem
+                                Text="{x:Bind domain:Translator.Buttons_Open}"
+                                Command="{Binding ElementName=root, Path=ViewModel.OpenAttachmentCommand}"
+                                CommandParameter="{x:Bind}">
+                                <MenuFlyoutItem.Icon>
+                                    <PathIcon Data="{StaticResource OpenFilePathIcon}" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                Text="{x:Bind domain:Translator.Buttons_Save}"
+                                Command="{Binding ElementName=root, Path=ViewModel.SaveAttachmentCommand}"
+                                CommandParameter="{x:Bind}">
+                                <MenuFlyoutItem.Icon>
+                                    <PathIcon Data="{StaticResource SaveAttachmentPathIcon}" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyout>
+                    </Grid.ContextFlyout>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="36" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-                <!--  Icon  -->
-                <ContentControl
-                    VerticalAlignment="Center"
-                    Content="{x:Bind AttachmentType}"
-                    ContentTemplateSelector="{StaticResource FileTypeIconSelector}" />
+                    <!--  Icon  -->
+                    <ContentControl
+                        VerticalAlignment="Center"
+                        Content="{x:Bind AttachmentType}"
+                        ContentTemplateSelector="{StaticResource FileTypeIconSelector}" />
 
-                <!--  Name && Size  -->
-                <Grid Grid.Column="1" VerticalAlignment="Center">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
+                    <!--  Name && Size  -->
+                    <Grid Grid.Column="1"
+                          VerticalAlignment="Center"
+                          Padding="0,0,5,0"
+                          MaxWidth="250">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
 
-                    <TextBlock
-                        FontSize="13"
-                        Text="{x:Bind FileName}"
-                        MaxLines="2"
-                        TextWrapping="Wrap"
-                        TextTrimming="CharacterEllipsis" />
+                        <TextBlock
+                            FontSize="13"
+                            Text="{x:Bind FileName}"
+                            MaxLines="1"
+                            TextWrapping="Wrap"
+                            TextTrimming="CharacterEllipsis" />
 
-                    <TextBlock
-                        Grid.Row="1"
-                        Margin="0,2,0,0"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Bottom"
-                        FontSize="11"
-                        Foreground="Gray"
-                        Text="{x:Bind ReadableSize}" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Margin="0,2,0,0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            FontSize="11"
+                            Foreground="Gray"
+                            Text="{x:Bind ReadableSize}" />
+                    </Grid>
                 </Grid>
-
-                <ProgressRing
-                    Grid.Column="2"
-                    VerticalAlignment="Center"
-                    IsActive="{x:Bind IsBusy, Mode=OneWay}" />
+                <muxc:ProgressBar
+                    Grid.Row="1"
+                    VerticalAlignment="Top"
+                    HorizontalAlignment="Stretch"
+                    Visibility="{x:Bind IsBusy, Mode=OneWay}"
+                    IsIndeterminate="{x:Bind IsBusy, Mode=OneWay}"
+                    ShowPaused="False"
+                    Margin="0, -5, 0,0"
+                    ShowError="False"/>
             </Grid>
+
         </DataTemplate>
 
     </Page.Resources>
@@ -292,20 +310,22 @@
             </Grid>
         </Grid>
 
-        <GridView
-            Grid.Row="2"
-            ui:ListViewExtensions.ItemContainerStretchDirection="Horizontal"
-            x:Name="AttachmentsListView"
-            x:Load="{x:Bind helpers:XamlHelpers.CountToBooleanConverter(ViewModel.Attachments.Count), Mode=OneWay}"
-            IsItemClickEnabled="True"
-            MaxHeight="200"
-            Padding="8,0,0,0"
-            ItemTemplate="{StaticResource FileAttachmentTemplate}"
-            ItemsSource="{x:Bind ViewModel.Attachments, Mode=OneWay}"
-            ScrollViewer.VerticalScrollBarVisibility="Visible"
-            ScrollViewer.VerticalScrollMode="Enabled"
-            ItemClick="AttachmentClicked"
-            SelectionMode="None" />
+        <!--  Attachments  -->
+        <ListView x:Name="AttachmentsListView"
+                  Grid.Row="2"
+                  x:Load="{x:Bind helpers:XamlHelpers.CountToBooleanConverter(ViewModel.Attachments.Count), Mode=OneWay}"
+                  IsItemClickEnabled="True"
+                  ItemTemplate="{StaticResource FileAttachmentTemplate}"
+                  ItemsSource="{x:Bind ViewModel.Attachments, Mode=OneWay}"
+                  ItemClick="AttachmentClicked"
+                  SelectionMode="None"
+                  Height="53">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <controls2:WrapPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+        </ListView>
 
         <muxc:ProgressBar
             x:Name="DownloadingProgressBar"

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -62,18 +62,17 @@
         <!--  Attachment Template  -->
         <!--  Margin -8 0 is used to remove the padding from the ListViewItem-->
         <DataTemplate x:Key="FileAttachmentTemplate" x:DataType="viewModelData:MailAttachmentViewModel">
-            <Grid Height="51" RowSpacing="0">
+            <Grid Height="51">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="50" />
-                    <RowDefinition Height="5" />
+                    <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Grid
                     Grid.Row="0"
                     Height="50"
                     Background="Transparent"
                     ColumnSpacing="3"
-                    Padding="0,0,5,0"
-                    Margin="-8 0">
+                    Margin="-8,0,0,0">
                     <ToolTipService.ToolTip>
                         <ToolTip Content="{x:Bind FileName}" />
                     </ToolTipService.ToolTip>
@@ -111,7 +110,6 @@
                     <!--  Name && Size  -->
                     <Grid Grid.Column="1"
                           VerticalAlignment="Center"
-                          Padding="0,0,5,0"
                           MaxWidth="200">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -127,7 +125,6 @@
 
                         <TextBlock
                             Grid.Row="1"
-                            Margin="0,2,0,0"
                             HorizontalAlignment="Right"
                             VerticalAlignment="Bottom"
                             FontSize="11"
@@ -139,7 +136,7 @@
                     Grid.Row="1"
                     VerticalAlignment="Top"
                     HorizontalAlignment="Stretch"
-                    Margin="0, -5, 0,0"
+                    Margin="0,-5,0,0"
                     Visibility="{x:Bind IsBusy, Mode=OneWay}"
                     IsIndeterminate="{x:Bind IsBusy, Mode=OneWay}"
                     ShowPaused="False"

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -65,7 +65,7 @@
             <Grid Height="51" RowSpacing="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="50" />
-                    <RowDefinition Height="*" />
+                    <RowDefinition Height="5" />
                 </Grid.RowDefinitions>
                 <Grid
                     Grid.Row="0"
@@ -111,8 +111,7 @@
                     <!--  Name && Size  -->
                     <Grid Grid.Column="1"
                           VerticalAlignment="Center"
-                          Padding="0,0,5,0"
-                          MaxWidth="250">
+                          Padding="0,0,5,0">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
@@ -139,10 +138,10 @@
                     Grid.Row="1"
                     VerticalAlignment="Top"
                     HorizontalAlignment="Stretch"
+                    Margin="0, -5, 0,0"
                     Visibility="{x:Bind IsBusy, Mode=OneWay}"
                     IsIndeterminate="{x:Bind IsBusy, Mode=OneWay}"
                     ShowPaused="False"
-                    Margin="0, -5, 0,0"
                     ShowError="False"/>
             </Grid>
 
@@ -319,7 +318,7 @@
                   ItemsSource="{x:Bind ViewModel.Attachments, Mode=OneWay}"
                   ItemClick="AttachmentClicked"
                   SelectionMode="None"
-                  Height="53">
+                  Height="55">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <controls2:WrapPanel Orientation="Horizontal"/>


### PR DESCRIPTION
Changes: 

1. fixed #180 crash
2. Each attachment now occupy less space (max width of text 200)
![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/0903594d-2530-4cdf-8b8a-928aa70b1f6b)

3. Replaced progress ring that was occupying space with progress bar ( And for me progress ring didn't work at all). Logic behind wasn't changed. 
![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/6e2a1616-240b-403b-9c2c-9a9ad0cd1dda)

4. Changed behavior when attachments overflowing available space. 
 Before there is no scrollbar and no way to reach attachments behind the screen: 
 ![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/1f61ead8-8a12-40eb-93ad-225c3c4c2c3b)
 After - In Reading page vertical scrollbar available to reach overflowed attachments. Only one row available by default to do not occupy a lot of space. In compose mode all attachments displayed in as many rows as needed ( you should all the time see on the screen what you will send)
![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/c07bf3d6-2e90-458f-b926-3be9565d1845)
![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/b1b6b82b-2a48-4441-b126-2c2ec08d9b4f)
Also now it shows only 1 line for name with TextTrimming="CharacterEllipsis". Size should not be missplaced if name is very long. It can be seen in before section for Azure Landing Zone (Spokes) file.
5. Added additional filter option "Has files". Currently without glyph: 
![image](https://github.com/bkaankose/Wino-Mail/assets/22834937/29d4f42f-6797-4f0a-9723-5fb7d6027709)


