### PR TITLE
Couple UI Fixes

### DIFF
--- a/Wino.Mail.ViewModels/ComposePageViewModel.cs
+++ b/Wino.Mail.ViewModels/ComposePageViewModel.cs
@@ -269,8 +269,6 @@ namespace Wino.Mail.ViewModels
             base.OnNavigatedFrom(mode, parameters);
 
             await UpdateMimeChangesAsync().ConfigureAwait(false);
-
-            await ExecuteUIThread(() => { _statePersistanceService.IsReadingMail = false; });
         }
 
         public override async void OnNavigatedTo(NavigationMode mode, object parameters)
@@ -288,8 +286,6 @@ namespace Wino.Mail.ViewModels
 
             ToItems.CollectionChanged -= ContactListCollectionChanged;
             ToItems.CollectionChanged += ContactListCollectionChanged;
-
-            _statePersistanceService.IsReadingMail = true;
 
             // Check if there is any delivering mail address from protocol launch.
 
@@ -388,6 +384,11 @@ namespace Wino.Mail.ViewModels
 
                 return;
             }
+            catch (IOException)
+            {
+                DialogService.InfoBarMessage("Busy", "Mail is being processed. Please wait a moment and try again.", InfoBarMessageType.Warning);
+            }
+
             catch (ComposerMimeNotFoundException)
             {
                 DialogService.InfoBarMessage(Translator.Info_ComposerMissingMIMETitle, Translator.Info_ComposerMissingMIMEMessage, InfoBarMessageType.Error);

--- a/Wino.Mail.ViewModels/ComposePageViewModel.cs
+++ b/Wino.Mail.ViewModels/ComposePageViewModel.cs
@@ -225,7 +225,14 @@ namespace Wino.Mail.ViewModels
         private async Task SaveBodyAsync()
         {
             if (GetHTMLBodyFunction != null)
-                bodyBuilder.HtmlBody = Regex.Unescape(await GetHTMLBodyFunction());
+            {
+                var htmlBody = await GetHTMLBodyFunction();
+
+                if (!string.IsNullOrEmpty(htmlBody))
+                {
+                    bodyBuilder.HtmlBody = Regex.Unescape(htmlBody);
+                }
+            }
 
             if (!string.IsNullOrEmpty(bodyBuilder.HtmlBody))
                 bodyBuilder.TextBody = HtmlAgilityPackExtensions.GetPreviewText(bodyBuilder.HtmlBody);

--- a/Wino.Mail.ViewModels/IdlePageViewModel.cs
+++ b/Wino.Mail.ViewModels/IdlePageViewModel.cs
@@ -1,38 +1,9 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Messaging;
-using Wino.Core.Domain;
-using Wino.Core.Domain.Interfaces;
-using Wino.Core.Domain.Models.Navigation;
-using Wino.Core.Messages.Mails;
+﻿using Wino.Core.Domain.Interfaces;
 
 namespace Wino.Mail.ViewModels
 {
-    public partial class IdlePageViewModel : BaseViewModel, IRecipient<SelectedMailItemsChanged>
+    public partial class IdlePageViewModel : BaseViewModel
     {
-        [ObservableProperty]
-        [NotifyPropertyChangedFor(nameof(HasSelectedItems))]
-        [NotifyPropertyChangedFor(nameof(SelectedMessageText))]
-        private int selectedItemCount;
-
-        public bool HasSelectedItems => SelectedItemCount > 0;
-
-        public string SelectedMessageText => HasSelectedItems ? string.Format(Translator.MailsSelected, SelectedItemCount) : Translator.NoMailSelected;
-
         public IdlePageViewModel(IDialogService dialogService) : base(dialogService) { }
-
-        public void Receive(SelectedMailItemsChanged message)
-        {
-            SelectedItemCount = message.SelectedItemCount;
-        }
-
-        public override void OnNavigatedTo(NavigationMode mode, object parameters)
-        {
-            base.OnNavigatedTo(mode, parameters);
-
-            if (parameters != null && parameters is int selectedItemCount)
-                SelectedItemCount = selectedItemCount;
-            else
-                SelectedItemCount = 0;
-        }
     }
 }

--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -460,8 +460,13 @@ namespace Wino.Mail.ViewModels
             initializedMailItemViewModel = null;
             initializedMimeMessageInformation = null;
 
-            StatePersistanceService.IsReadingMail = false;
             forceImageLoading = false;
+
+            ToItems.Clear();
+            CCItemsItems.Clear();
+            BCCItems.Clear();
+            Attachments.Clear();
+            MenuItems.Clear();
         }
 
         private void LoadAddressInfo(InternetAddressList list, ObservableCollection<AddressInformation> collection)

--- a/Wino.Mail/App.xaml.cs
+++ b/Wino.Mail/App.xaml.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
@@ -12,9 +11,7 @@ using Serilog;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.ApplicationModel.Core;
-using Windows.ApplicationModel.Resources;
 using Windows.Foundation.Metadata;
-using Windows.Globalization;
 using Windows.Storage;
 using Windows.System.Profile;
 using Windows.UI;

--- a/Wino.Mail/Services/WinoNavigationService.cs
+++ b/Wino.Mail/Services/WinoNavigationService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using CommunityToolkit.Mvvm.Messaging;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -18,6 +19,14 @@ namespace Wino.Services
 {
     public class WinoNavigationService : IWinoNavigationService
     {
+        private readonly IStatePersistanceService _statePersistanceService;
+
+        private WinoPage[] _renderingPageTypes = new WinoPage[]
+        {
+            WinoPage.MailRenderingPage,
+            WinoPage.ComposePage
+        };
+
         private Frame GetCoreFrame(NavigationReferenceFrame frameType)
         {
             if (Window.Current.Content is Frame appFrame && appFrame.Content is AppShell shellPage)
@@ -34,6 +43,11 @@ namespace Wino.Services
             {
                 return null;
             }
+        }
+
+        public WinoNavigationService(IStatePersistanceService statePersistanceService)
+        {
+            _statePersistanceService = statePersistanceService;
         }
 
         private Type GetPageType(WinoPage winoPage)
@@ -84,6 +98,8 @@ namespace Wino.Services
         {
             var pageType = GetPageType(page);
             Frame shellFrame = GetCoreFrame(NavigationReferenceFrame.ShellFrame);
+
+            _statePersistanceService.IsReadingMail = _renderingPageTypes.Contains(page);
 
             if (shellFrame != null)
             {

--- a/Wino.Mail/Views/ComposePage.xaml.cs
+++ b/Wino.Mail/Views/ComposePage.xaml.cs
@@ -46,8 +46,6 @@ namespace Wino.Views
         }
 
         public static readonly DependencyProperty IsComposerDarkModeProperty = DependencyProperty.Register(nameof(IsComposerDarkMode), typeof(bool), typeof(ComposePage), new PropertyMetadata(false, OnIsComposerDarkModeChanged));
-
-
         public WebView2 GetWebView() => Chromium;
 
         private TaskCompletionSource<bool> DOMLoadedTask = new TaskCompletionSource<bool>();
@@ -336,6 +334,12 @@ namespace Wino.Views
             base.OnNavigatingFrom(e);
 
             DisposeDisposables();
+            DisposeWebView2();
+        }
+
+        private void DisposeWebView2()
+        {
+            if (Chromium == null) return;
 
             Chromium.CoreWebView2Initialized -= ChromiumInitialized;
 
@@ -344,6 +348,9 @@ namespace Wino.Views
                 Chromium.CoreWebView2.DOMContentLoaded -= DOMLoaded;
                 Chromium.CoreWebView2.WebMessageReceived -= ScriptMessageRecieved;
             }
+
+            Chromium.Close();
+            GC.Collect();
         }
 
         private void DisposeDisposables()

--- a/Wino.Mail/Views/IdlePage.xaml
+++ b/Wino.Mail/Views/IdlePage.xaml
@@ -9,22 +9,7 @@
     xmlns:controls="using:Wino.Controls"
     mc:Ignorable="d">
 
-    <!--  Empty Page for Mail Rendering Sub Frame.  -->
-    <Grid>
-        <StackPanel
-            Opacity="0.5"
-            Spacing="6"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center">
+    <!--  Empty page for disposing composer or renderer page.  -->
+    <Grid />
 
-            <controls:WinoFontIcon Icon="Mail" FontSize="80" />
-
-            <TextBlock
-                HorizontalAlignment="Center"
-                FontSize="31"
-                Text="{x:Bind ViewModel.SelectedMessageText, Mode=OneWay}"
-                Style="{StaticResource SubheaderTextBlockStyle}"
-                x:Name="CountTextBlock" />
-        </StackPanel>
-    </Grid>
 </abstract:IdlePageAbstract>

--- a/Wino.Mail/Views/MailListPage.xaml
+++ b/Wino.Mail/Views/MailListPage.xaml
@@ -20,6 +20,7 @@
     xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
     xmlns:viewModelData="using:Wino.Mail.ViewModels.Data"
     xmlns:wino="using:Wino"
+    xmlns:converters="using:Wino.Converters"
     x:Name="root"
     Loaded="MailListPageLoaded"
     mc:Ignorable="d">
@@ -478,6 +479,7 @@
                                 x:Name="SelectionModeToggle"
                                 Grid.Column="1"
                                 Checked="SelectionModeToggleChecked"
+                                IsChecked="{x:Bind ViewModel.IsMultiSelectionModeEnabled, Mode=TwoWay}"
                                 Style="{StaticResource TopCommandBarToggleButtonStyle}"
                                 Unchecked="SelectionModeToggleUnchecked">
                                 <ToggleButton.Content>
@@ -807,13 +809,28 @@
             </Grid>
         </Border>
 
-        <!--  Mail Rendering Frame  -->
-        <Frame
-            x:Name="RenderingFrame"
-            Grid.Column="1"
-            IsNavigationStackEnabled="False" />
+        <Grid Grid.Column="1" x:Name="RenderingGrid">
+            <!--  Mail Rendering Frame  -->
+            <Frame x:Name="RenderingFrame" IsNavigationStackEnabled="False"  />
 
+            <!--  No Mail Selected Message  -->
+            <StackPanel
+                x:Name="NoMailSelectedPanel"
+                Opacity="0.5"
+                Spacing="6"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
 
+                <controls:WinoFontIcon Icon="Mail" FontSize="80" />
+
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    FontSize="31"
+                    Text="{x:Bind ViewModel.SelectedMessageText, Mode=OneWay}"
+                    Style="{StaticResource SubheaderTextBlockStyle}"
+                    x:Name="CountTextBlock" />
+            </StackPanel>
+        </Grid>
 
 
         <VisualStateManager.VisualStateGroups>

--- a/Wino.Mail/Views/MailListPage.xaml.cs
+++ b/Wino.Mail/Views/MailListPage.xaml.cs
@@ -44,6 +44,7 @@ namespace Wino.Views
 
         private IStatePersistanceService StatePersistanceService { get; } = App.Current.Services.GetService<IStatePersistanceService>();
         private IPreferencesService PreferencesService { get; } = App.Current.Services.GetService<IPreferencesService>();
+        private IKeyPressService KeyPressService { get; } = App.Current.Services.GetService<IKeyPressService>();
 
         public MailListPage()
         {
@@ -67,13 +68,9 @@ namespace Wino.Views
         {
             base.OnNavigatedFrom(e);
 
-            // Force to go to empty page to dispose compose or rendering.
-            if (!(RenderingFrame.Content is IdlePage))
-            {
-                RenderingFrame.Navigate(typeof(IdlePage), null);
-            }
-
             this.Bindings.StopTracking();
+
+            RenderingFrame.Navigate(typeof(IdlePage));
 
             GC.Collect();
         }
@@ -153,35 +150,61 @@ namespace Wino.Views
 
         private void UpdateAdaptiveness()
         {
-            var readerGridVisibility = !(StatePersistanceService.IsReadingMail && StatePersistanceService.IsReaderNarrowed) ? Visibility.Visible : Visibility.Collapsed;
-            ReaderGridContainer.Visibility = readerGridVisibility;
-            ReaderGrid.Visibility = readerGridVisibility;
-            RenderingFrame.Visibility = StatePersistanceService.IsReadingMail ? Visibility.Visible : (StatePersistanceService.IsReaderNarrowed ? Visibility.Collapsed : Visibility.Visible);
 
-            if (RenderingFrame.Visibility == Visibility.Collapsed)
+            bool shouldDisplayNoMessagePanel, shouldDisplayMailingList, shouldDisplayRenderingFrame;
+
+            // This is the smallest state UI can get.
+            // Either mailing list or rendering grid is visible.
+            if (StatePersistanceService.IsReaderNarrowed)
             {
-                Grid.SetColumn(ReaderGrid, 0);
-                Grid.SetColumnSpan(ReaderGrid, 2);
-                Grid.SetColumn(ReaderGridContainer, 0);
-                Grid.SetColumnSpan(ReaderGridContainer, 2);
+                // Start visibility checks by no message panel.
+
+                bool isMultiSelectionEnabled = ViewModel.IsMultiSelectionModeEnabled || KeyPressService.IsCtrlKeyPressed();
+
+                shouldDisplayMailingList = isMultiSelectionEnabled ? true : (!ViewModel.HasSelectedItems || ViewModel.HasMultipleItemSelections);
+                shouldDisplayNoMessagePanel = shouldDisplayMailingList ? false : !ViewModel.HasSelectedItems || ViewModel.HasMultipleItemSelections;
+                shouldDisplayRenderingFrame = shouldDisplayMailingList ? false : !shouldDisplayNoMessagePanel;
             }
             else
             {
-                Grid.SetColumn(ReaderGrid, 0);
-                Grid.SetColumnSpan(ReaderGrid, 1);
+                shouldDisplayMailingList = true;
+                shouldDisplayNoMessagePanel = !ViewModel.HasSelectedItems || ViewModel.HasMultipleItemSelections;
+                shouldDisplayRenderingFrame = !shouldDisplayNoMessagePanel;
+            }
+
+            ReaderGridContainer.Visibility = shouldDisplayMailingList ? Visibility.Visible : Visibility.Collapsed;
+            RenderingFrame.Visibility = shouldDisplayRenderingFrame ? Visibility.Visible : Visibility.Collapsed;
+            NoMailSelectedPanel.Visibility = shouldDisplayNoMessagePanel ? Visibility.Visible : Visibility.Collapsed;
+
+            if (StatePersistanceService.IsReaderNarrowed)
+            {
+                if (RenderingFrame.Visibility == Visibility.Visible && ReaderGridContainer.Visibility == Visibility.Collapsed)
+                {
+                    // Extend rendering frame to full width.
+                    Grid.SetColumn(RenderingGrid, 0);
+                    Grid.SetColumnSpan(RenderingGrid, 2);
+
+                    Grid.SetColumn(ReaderGrid, 0);
+                    Grid.SetColumnSpan(ReaderGrid, 2);
+                }
+                else if (RenderingFrame.Visibility == Visibility.Collapsed && NoMailSelectedPanel.Visibility == Visibility.Collapsed)
+                {
+                    // Only mail list is available.
+                    // Extend the mailing list.
+                    Grid.SetColumn(ReaderGridContainer, 0);
+                    Grid.SetColumnSpan(ReaderGridContainer, 2);
+                }
+            }
+            else
+            {
+                // Mailing list is always visible on the first part.
+
                 Grid.SetColumn(ReaderGridContainer, 0);
                 Grid.SetColumnSpan(ReaderGridContainer, 1);
-            }
 
-            if (ReaderGrid.Visibility == Visibility.Collapsed)
-            {
-                Grid.SetColumn(RenderingFrame, 0);
-                Grid.SetColumnSpan(RenderingFrame, 2);
-            }
-            else
-            {
-                Grid.SetColumn(RenderingFrame, 1);
-                Grid.SetColumnSpan(RenderingFrame, 1);
+                // Rendering grid should take the rest of the space.
+                Grid.SetColumn(RenderingGrid, 1);
+                Grid.SetColumnSpan(RenderingGrid, 1);
             }
         }
 
@@ -264,7 +287,7 @@ namespace Wino.Views
             {
                 WeakReferenceMessenger.Default.Send(new CancelRenderingContentRequested());
 
-                ViewModel.NavigationService.Navigate(WinoPage.IdlePage, ViewModel.SelectedItemCount, NavigationReferenceFrame.RenderingFrame);
+                ViewModel.NavigationService.Navigate(WinoPage.IdlePage, null, NavigationReferenceFrame.RenderingFrame, NavigationTransitionType.None);
             }
             else
             {
@@ -358,11 +381,6 @@ namespace Wino.Views
 
         public void Receive(ActiveMailFolderChangedEvent message)
         {
-            if (!(RenderingFrame.Content is IdlePage))
-            {
-                RenderingFrame.Navigate(typeof(IdlePage), null);
-            }
-
             UpdateAdaptiveness();
         }
 

--- a/Wino.Mail/Views/MailListPage.xaml.cs
+++ b/Wino.Mail/Views/MailListPage.xaml.cs
@@ -286,8 +286,6 @@ namespace Wino.Views
             if (message.SelectedMailItemViewModel == null)
             {
                 WeakReferenceMessenger.Default.Send(new CancelRenderingContentRequested());
-
-                ViewModel.NavigationService.Navigate(WinoPage.IdlePage, null, NavigationReferenceFrame.RenderingFrame, NavigationTransitionType.None);
             }
             else
             {
@@ -320,7 +318,6 @@ namespace Wino.Views
                     // Find the MIME and go to rendering page.
 
                     if (message.SelectedMailItemViewModel == null) return;
-
 
                     if (IsComposingPageActive())
                     {

--- a/Wino.Mail/Wino.Mail.csproj
+++ b/Wino.Mail/Wino.Mail.csproj
@@ -246,7 +246,6 @@
     <Compile Include="Controls\WinoFontIconSource.cs" />
     <Compile Include="Controls\WinoFontIcon.cs" />
     <Compile Include="Controls\WinoSwipeControlItems.cs" />
-    <Compile Include="Converters\ReverseVisibilityConverter.cs" />
     <Compile Include="Dialogs\AccountEditDialog.xaml.cs">
       <DependentUpon>AccountEditDialog.xaml</DependentUpon>
     </Compile>

--- a/Wino.Mail/Wino.Mail.csproj
+++ b/Wino.Mail/Wino.Mail.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Controls\WinoFontIconSource.cs" />
     <Compile Include="Controls\WinoFontIcon.cs" />
     <Compile Include="Controls\WinoSwipeControlItems.cs" />
+    <Compile Include="Converters\ReverseVisibilityConverter.cs" />
     <Compile Include="Dialogs\AccountEditDialog.xaml.cs">
       <DependentUpon>AccountEditDialog.xaml</DependentUpon>
     </Compile>
@@ -588,8 +589,8 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\IdlePage.xaml">
-      <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\ImapSetup\AdvancedImapSetupPage.xaml">
       <SubType>Designer</SubType>


### PR DESCRIPTION
- Disabled navigation UI cache. All pages are re-created from scratch and corresponding WebView2 instances are now disposed correctly. Previously they used to sit in the memory even though when the users were not using them.
- Restored the animation from rendering page to composer page. It was lost due to IdlePage functionality.
- IdlePage functionality is moved to listing page. Selected items' management is now handled there.
- Fixed couple UI bugs around visual states and multi selection.