### PR TITLE
Fix account signature preferences during draft creation

### DIFF
--- a/Wino.Core.Domain/Interfaces/IMailService.cs
+++ b/Wino.Core.Domain/Interfaces/IMailService.cs
@@ -103,9 +103,9 @@ namespace Wino.Core.Domain.Interfaces
         /// Creates a draft MailCopy and MimeMessage based on the given options.
         /// For forward/reply it would include the referenced message.
         /// </summary>
-        /// <param name="composerAccount">Account which should have new draft.</param>
+        /// <param name="accountId">AccountId which should have new draft.</param>
         /// <param name="draftCreationOptions">Options like new email/forward/draft.</param>
         /// <returns>Draft MailCopy and Draft MimeMessage as base64.</returns>
-        Task<(MailCopy draftMailCopy, string draftBase64MimeMessage)> CreateDraftAsync(MailAccount composerAccount, DraftCreationOptions draftCreationOptions);
+        Task<(MailCopy draftMailCopy, string draftBase64MimeMessage)> CreateDraftAsync(Guid accountId, DraftCreationOptions draftCreationOptions);
     }
 }

--- a/Wino.Core/Services/MailService.cs
+++ b/Wino.Core/Services/MailService.cs
@@ -51,8 +51,9 @@ namespace Wino.Core.Services
             _preferencesService = preferencesService;
         }
 
-        public async Task<(MailCopy draftMailCopy, string draftBase64MimeMessage)> CreateDraftAsync(MailAccount composerAccount, DraftCreationOptions draftCreationOptions)
+        public async Task<(MailCopy draftMailCopy, string draftBase64MimeMessage)> CreateDraftAsync(Guid accountId, DraftCreationOptions draftCreationOptions)
         {
+            var composerAccount = await _accountService.GetAccountAsync(accountId);
             var createdDraftMimeMessage = await CreateDraftMimeAsync(composerAccount, draftCreationOptions);
 
             var draftFolder = await _folderService.GetSpecialFolderByAccountIdAsync(composerAccount.Id, SpecialFolderType.Draft);

--- a/Wino.Core/Services/MailService.cs
+++ b/Wino.Core/Services/MailService.cs
@@ -53,7 +53,7 @@ namespace Wino.Core.Services
 
         public async Task<(MailCopy draftMailCopy, string draftBase64MimeMessage)> CreateDraftAsync(Guid accountId, DraftCreationOptions draftCreationOptions)
         {
-            var composerAccount = await _accountService.GetAccountAsync(accountId);
+            var composerAccount = await _accountService.GetAccountAsync(accountId).ConfigureAwait(false);
             var createdDraftMimeMessage = await CreateDraftMimeAsync(composerAccount, draftCreationOptions);
 
             var draftFolder = await _folderService.GetSpecialFolderByAccountIdAsync(composerAccount.Id, SpecialFolderType.Draft);

--- a/Wino.Mail.ViewModels/AppShellViewModel.cs
+++ b/Wino.Mail.ViewModels/AppShellViewModel.cs
@@ -777,7 +777,7 @@ namespace Wino.Mail.ViewModels
                 MailToUri = _launchProtocolService.MailToUri
             };
 
-            var (draftMailCopy, draftBase64MimeMessage) = await _mailService.CreateDraftAsync(account, draftOptions).ConfigureAwait(false);
+            var (draftMailCopy, draftBase64MimeMessage) = await _mailService.CreateDraftAsync(account.Id, draftOptions).ConfigureAwait(false);
 
             var draftPreparationRequest = new DraftPreparationRequest(account, draftMailCopy, draftBase64MimeMessage);
             await _winoRequestDelegator.ExecuteAsync(draftPreparationRequest);

--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -271,7 +271,7 @@ namespace Wino.Mail.ViewModels
                     }
                 };
 
-                var (draftMailCopy, draftBase64MimeMessage) = await _mailService.CreateDraftAsync(initializedMailItemViewModel.AssignedAccount, draftOptions).ConfigureAwait(false);
+                var (draftMailCopy, draftBase64MimeMessage) = await _mailService.CreateDraftAsync(initializedMailItemViewModel.AssignedAccount.Id, draftOptions).ConfigureAwait(false);
 
                 var draftPreparationRequest = new DraftPreparationRequest(initializedMailItemViewModel.AssignedAccount, draftMailCopy, draftBase64MimeMessage, initializedMailItemViewModel.MailCopy);
 


### PR DESCRIPTION
Pass account id instead of account since account.preferences object is not guaranteed to be latest.