### PR TITLE
Fixing sharing logs

### DIFF
--- a/Wino.Core.Domain/Constants.cs
+++ b/Wino.Core.Domain/Constants.cs
@@ -13,5 +13,6 @@
 
         public const string ClientLogFile = "Client_.log";
         public const string ServerLogFile = "Server_.log";
+        public const string LogArchiveFileName = "WinoLogs.zip";
     }
 }

--- a/Wino.Core.Domain/Interfaces/IFileService.cs
+++ b/Wino.Core.Domain/Interfaces/IFileService.cs
@@ -8,5 +8,13 @@ namespace Wino.Core.Domain.Interfaces
         Task<string> CopyFileAsync(string sourceFilePath, string destinationFolderPath);
         Task<Stream> GetFileStreamAsync(string folderPath, string fileName);
         Task<string> GetFileContentByApplicationUriAsync(string resourcePath);
+
+        /// <summary>
+        /// Zips all existing logs and saves to picked destination folder.
+        /// </summary>
+        /// <param name="logsFolder">Folder path where logs are stored.</param>
+        /// <param name="destinationFolder">Target path to save the archive file.</param>
+        /// <returns>True if zip is created with at least one item, false if logs are not found.</returns>
+        Task<bool> SaveLogsToFolderAsync(string logsFolder, string destinationFolder);
     }
 }

--- a/Wino.Mail.ViewModels/AboutPageViewModel.cs
+++ b/Wino.Mail.ViewModels/AboutPageViewModel.cs
@@ -1,14 +1,13 @@
 ﻿using System;
-using System.IO;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using Wino.Core.Domain;
+using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Interfaces;
-using Wino.Core.Services;
 
 namespace Wino.Mail.ViewModels
 {
-    public class AboutPageViewModel : BaseViewModel
+    public partial class AboutPageViewModel : BaseViewModel
     {
         private readonly IStoreRatingService _storeRatingService;
         private readonly INativeAppService _nativeAppService;
@@ -22,9 +21,6 @@ namespace Wino.Mail.ViewModels
         public string PrivacyPolicyUrl => "https://www.winomail.app/privacy_policy.html";
         public string PaypalUrl => "https://paypal.me/bkaankose?country.x=PL&locale.x=en_US";
 
-        public AsyncRelayCommand<object> NavigateCommand { get; set; }
-        public AsyncRelayCommand ShareWinoLogCommand { get; set; }
-        public AsyncRelayCommand ShareProtocolLogCommand { get; set; }
         public IPreferencesService PreferencesService { get; }
 
         public AboutPageViewModel(IStoreRatingService storeRatingService,
@@ -42,9 +38,6 @@ namespace Wino.Mail.ViewModels
             _fileService = fileService;
 
             PreferencesService = preferencesService;
-            NavigateCommand = new AsyncRelayCommand<object>(Navigate);
-            ShareWinoLogCommand = new AsyncRelayCommand(ShareWinoLogAsync);
-            ShareProtocolLogCommand = new AsyncRelayCommand(ShareProtocolLogAsync);
         }
 
         protected override void OnActivated()
@@ -70,35 +63,28 @@ namespace Wino.Mail.ViewModels
             }
         }
 
-        private Task ShareProtocolLogAsync()
-            => SaveLogInternalAsync(ImapTestService.ProtocolLogFileName);
-
-        private Task ShareWinoLogAsync()
-            => SaveLogInternalAsync(Constants.ClientLogFile);
-
-        private async Task SaveLogInternalAsync(string sourceFileName)
+        [RelayCommand]
+        private async Task ShareWinoLogAsync()
         {
             var appDataFolder = _appInitializerService.ApplicationDataFolderPath;
-
-            var logFile = Path.Combine(appDataFolder, sourceFileName);
-
-            if (!File.Exists(logFile))
-            {
-                DialogService.InfoBarMessage(Translator.Info_LogsNotFoundTitle, Translator.Info_LogsNotFoundMessage, Core.Domain.Enums.InfoBarMessageType.Warning);
-                return;
-            }
 
             var selectedFolderPath = await DialogService.PickWindowsFolderAsync();
 
             if (string.IsNullOrEmpty(selectedFolderPath)) return;
 
-            var copiedFilePath = await _fileService.CopyFileAsync(logFile, selectedFolderPath);
+            var areLogsSaved = await _fileService.SaveLogsToFolderAsync(appDataFolder, selectedFolderPath).ConfigureAwait(false);
 
-            var copiedFileName = Path.GetFileName(copiedFilePath);
-
-            DialogService.InfoBarMessage(Translator.Info_LogsSavedTitle, string.Format(Translator.Info_LogsSavedMessage, copiedFileName), Core.Domain.Enums.InfoBarMessageType.Success);
+            if (areLogsSaved)
+            {
+                DialogService.InfoBarMessage(Translator.Info_LogsSavedTitle, string.Format(Translator.Info_LogsSavedMessage, Constants.LogArchiveFileName), InfoBarMessageType.Success);
+            }
+            else
+            {
+                DialogService.InfoBarMessage(Translator.Info_LogsNotFoundTitle, Translator.Info_LogsNotFoundMessage, InfoBarMessageType.Error);
+            }
         }
 
+        [RelayCommand]
         private async Task Navigate(object url)
         {
             if (url is string stringUrl)

--- a/Wino.Mail/Views/Settings/AboutPage.xaml
+++ b/Wino.Mail/Views/Settings/AboutPage.xaml
@@ -135,7 +135,7 @@
                 <controls:SettingsExpander.Items>
                     <controls:SettingsCard Header="{x:Bind domain:Translator.SettingsEnableLogs_Title}" Description="{x:Bind domain:Translator.SettingsEnableLogs_Description}">
                         <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button Content="Share" Command="{x:Bind ViewModel.ShareWinoLogCommand}" />
+                            <Button Content="{x:Bind domain:Translator.Buttons_Share}" Command="{x:Bind ViewModel.ShareWinoLogCommand}" />
                             <ToggleSwitch IsOn="{x:Bind ViewModel.PreferencesService.IsLoggingEnabled, Mode=TwoWay}" />
                         </StackPanel>
                     </controls:SettingsCard>

--- a/Wino.Mail/Views/Settings/AboutPage.xaml
+++ b/Wino.Mail/Views/Settings/AboutPage.xaml
@@ -61,9 +61,9 @@
                 </controls:SettingsCard.HeaderIcon>
                 <controls:SettingsCard.ActionIcon>
                     <PathIcon
-                         HorizontalAlignment="Center"
-                         VerticalAlignment="Center"
-                         Data="{StaticResource OpenInNewWindowPathIcon}" />
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Data="{StaticResource OpenInNewWindowPathIcon}" />
                 </controls:SettingsCard.ActionIcon>
             </controls:SettingsCard>
 
@@ -81,9 +81,9 @@
                 </controls:SettingsCard.HeaderIcon>
                 <controls:SettingsCard.ActionIcon>
                     <PathIcon
-                         HorizontalAlignment="Center"
-                         VerticalAlignment="Center"
-                         Data="{StaticResource OpenInNewWindowPathIcon}" />
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Data="{StaticResource OpenInNewWindowPathIcon}" />
                 </controls:SettingsCard.ActionIcon>
             </controls:SettingsCard>
 
@@ -98,9 +98,9 @@
                 </controls:SettingsCard.HeaderIcon>
                 <controls:SettingsCard.ActionIcon>
                     <PathIcon
-                         HorizontalAlignment="Center"
-                         VerticalAlignment="Center"
-                         Data="{StaticResource OpenInNewWindowPathIcon}" />
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Data="{StaticResource OpenInNewWindowPathIcon}" />
                 </controls:SettingsCard.ActionIcon>
             </controls:SettingsCard>
 
@@ -118,9 +118,9 @@
                 </controls:SettingsCard.HeaderIcon>
                 <controls:SettingsCard.ActionIcon>
                     <PathIcon
-                         HorizontalAlignment="Center"
-                         VerticalAlignment="Center"
-                         Data="{StaticResource OpenInNewWindowPathIcon}" />
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Data="{StaticResource OpenInNewWindowPathIcon}" />
                 </controls:SettingsCard.ActionIcon>
             </controls:SettingsCard>
 
@@ -137,13 +137,6 @@
                         <StackPanel Orientation="Horizontal" Spacing="12">
                             <Button Content="Share" Command="{x:Bind ViewModel.ShareWinoLogCommand}" />
                             <ToggleSwitch IsOn="{x:Bind ViewModel.PreferencesService.IsLoggingEnabled, Mode=TwoWay}" />
-                        </StackPanel>
-                    </controls:SettingsCard>
-
-                    <controls:SettingsCard Header="{x:Bind domain:Translator.SettingsEnableIMAPLogs_Title}" Description="{x:Bind domain:Translator.SettingsEnableIMAPLogs_Description}">
-                        <StackPanel Orientation="Horizontal" Spacing="12">
-                            <Button Content="{x:Bind domain:Translator.Buttons_Share}" Command="{x:Bind ViewModel.ShareProtocolLogCommand}" />
-                            <ToggleSwitch IsOn="{x:Bind ViewModel.PreferencesService.IsMailkitProtocolLoggerEnabled, Mode=TwoWay}" />
                         </StackPanel>
                     </controls:SettingsCard>
                 </controls:SettingsExpander.Items>


### PR DESCRIPTION
This PR reworks broken log sharing mechanism. With the server implementation, logs are separated as client - server and retention is introduced. This made log file names to be dynamic and categorized.

With these changes all existing logs are archived in zip file for the selected destination folder. Also removed obsolete imap protocol log sharing during imap account setup since all protocol log can be copied during the new imap setup dialog in case of errors.