### PR TITLE
Account contact pictures

### DIFF
--- a/Wino.Core.Domain/Entities/AccountContact.cs
+++ b/Wino.Core.Domain/Entities/AccountContact.cs
@@ -17,6 +17,7 @@ namespace Wino.Core.Domain.Entities
         public string Address { get; set; }
         public string Name { get; set; }
         public string Base64ContactPicture { get; set; }
+        public bool IsRootContact { get; set; }
 
         public string DisplayName => Address == Name ? Address : $"{Name} <{Address}>";
 

--- a/Wino.Core.Domain/Entities/AccountContact.cs
+++ b/Wino.Core.Domain/Entities/AccountContact.cs
@@ -1,6 +1,6 @@
-﻿using SQLite;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using SQLite;
 
 namespace Wino.Core.Domain.Entities
 {
@@ -9,23 +9,23 @@ namespace Wino.Core.Domain.Entities
     /// These values will be inserted during MIME fetch.
     /// </summary>
 
-
     // TODO: This can easily evolve to Contact store, just like People app in Windows 10/11.
     // Do it.
-    public class AddressInformation : IEquatable<AddressInformation>
+    public class AccountContact : IEquatable<AccountContact>
     {
         [PrimaryKey]
         public string Address { get; set; }
         public string Name { get; set; }
+        public string Base64ContactPicture { get; set; }
 
         public string DisplayName => Address == Name ? Address : $"{Name} <{Address}>";
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as AddressInformation);
+            return Equals(obj as AccountContact);
         }
 
-        public bool Equals(AddressInformation other)
+        public bool Equals(AccountContact other)
         {
             return !(other is null) &&
                    Address == other.Address &&
@@ -40,12 +40,12 @@ namespace Wino.Core.Domain.Entities
             return hashCode;
         }
 
-        public static bool operator ==(AddressInformation left, AddressInformation right)
+        public static bool operator ==(AccountContact left, AccountContact right)
         {
-            return EqualityComparer<AddressInformation>.Default.Equals(left, right);
+            return EqualityComparer<AccountContact>.Default.Equals(left, right);
         }
 
-        public static bool operator !=(AddressInformation left, AddressInformation right)
+        public static bool operator !=(AccountContact left, AccountContact right)
         {
             return !(left == right);
         }

--- a/Wino.Core.Domain/Entities/MailCopy.cs
+++ b/Wino.Core.Domain/Entities/MailCopy.cs
@@ -141,6 +141,15 @@ namespace Wino.Core.Domain.Entities
         /// </summary>
         [Ignore]
         public MailAccount AssignedAccount { get; set; }
+
+        /// <summary>
+        /// Contact information of the sender if exists.
+        /// Warning: This field is not populated by queries.
+        /// Services or View Models are responsible for populating this field.
+        /// </summary>
+        [Ignore]
+        public AccountContact SenderContact { get; set; }
+
         public IEnumerable<Guid> GetContainingIds() => [UniqueId];
         public override string ToString() => $"{Subject} <-> {Id}";
     }

--- a/Wino.Core.Domain/Interfaces/IBackgroundTaskService.cs
+++ b/Wino.Core.Domain/Interfaces/IBackgroundTaskService.cs
@@ -1,10 +1,18 @@
-﻿namespace Wino.Core.Domain.Interfaces
+﻿using System.Threading.Tasks;
+
+namespace Wino.Core.Domain.Interfaces
 {
     public interface IBackgroundTaskService
     {
         /// <summary>
-        /// Unregisters all existing background tasks. Useful for migrations.
+        /// Unregisters all background tasks once.
+        /// This is used to clean up the background tasks when the app is updated.
         /// </summary>
         void UnregisterAllBackgroundTask();
+
+        /// <summary>
+        /// Registers required background tasks.
+        /// </summary>
+        Task RegisterBackgroundTasksAsync();
     }
 }

--- a/Wino.Core.Domain/Models/MailItem/IMailItem.cs
+++ b/Wino.Core.Domain/Models/MailItem/IMailItem.cs
@@ -29,5 +29,6 @@ namespace Wino.Core.Domain.Models.MailItem
 
         MailItemFolder AssignedFolder { get; }
         MailAccount AssignedAccount { get; }
+        AccountContact SenderContact { get; }
     }
 }

--- a/Wino.Core.Domain/Models/MailItem/ThreadMailItem.cs
+++ b/Wino.Core.Domain/Models/MailItem/ThreadMailItem.cs
@@ -85,6 +85,8 @@ namespace Wino.Core.Domain.Models.MailItem
 
         public Guid FileId => LatestMailItem?.FileId ?? Guid.Empty;
 
+        public AccountContact SenderContact => LatestMailItem?.SenderContact;
+
         #endregion
     }
 }

--- a/Wino.Core/Extensions/MimeExtensions.cs
+++ b/Wino.Core/Extensions/MimeExtensions.cs
@@ -7,8 +7,6 @@ using MimeKit;
 using MimeKit.IO;
 using MimeKit.IO.Filters;
 using MimeKit.Utils;
-using Wino.Core.Domain;
-using Wino.Core.Domain.Entities;
 
 namespace Wino.Core.Extensions
 {
@@ -41,16 +39,6 @@ namespace Wino.Core.Extensions
             }
         }
 
-        public static AccountContact ToAddressInformation(this MailboxAddress address)
-        {
-            if (address == null)
-                return new AccountContact() { Name = Translator.UnknownSender, Address = Translator.UnknownAddress };
-
-            if (string.IsNullOrEmpty(address.Name))
-                address.Name = address.Address;
-
-            return new AccountContact() { Name = address.Name, Address = address.Address };
-        }
 
         /// <summary>
         /// Sets html body replacing base64 images with cid linked resources.

--- a/Wino.Core/Extensions/MimeExtensions.cs
+++ b/Wino.Core/Extensions/MimeExtensions.cs
@@ -41,15 +41,15 @@ namespace Wino.Core.Extensions
             }
         }
 
-        public static AddressInformation ToAddressInformation(this MailboxAddress address)
+        public static AccountContact ToAddressInformation(this MailboxAddress address)
         {
             if (address == null)
-                return new AddressInformation() { Name = Translator.UnknownSender, Address = Translator.UnknownAddress };
+                return new AccountContact() { Name = Translator.UnknownSender, Address = Translator.UnknownAddress };
 
             if (string.IsNullOrEmpty(address.Name))
                 address.Name = address.Address;
 
-            return new AddressInformation() { Name = address.Name, Address = address.Address };
+            return new AccountContact() { Name = address.Name, Address = address.Address };
         }
 
         /// <summary>

--- a/Wino.Core/Services/AccountService.cs
+++ b/Wino.Core/Services/AccountService.cs
@@ -332,6 +332,17 @@ namespace Wino.Core.Services
                 account.SenderName = profileInformation.SenderName;
                 account.Base64ProfilePictureData = profileInformation.Base64ProfilePictureData;
 
+                // Forcefully add or update a contact data with the provided information.
+
+                var accountContact = new AccountContact()
+                {
+                    Address = account.Address,
+                    Name = account.SenderName,
+                    Base64ContactPicture = account.Base64ProfilePictureData
+                };
+
+                await Connection.InsertOrReplaceAsync(accountContact).ConfigureAwait(false);
+
                 await UpdateAccountAsync(account).ConfigureAwait(false);
             }
         }

--- a/Wino.Core/Services/AccountService.cs
+++ b/Wino.Core/Services/AccountService.cs
@@ -338,7 +338,8 @@ namespace Wino.Core.Services
                 {
                     Address = account.Address,
                     Name = account.SenderName,
-                    Base64ContactPicture = account.Base64ProfilePictureData
+                    Base64ContactPicture = account.Base64ProfilePictureData,
+                    IsRootContact = true
                 };
 
                 await Connection.InsertOrReplaceAsync(accountContact).ConfigureAwait(false);

--- a/Wino.Core/Services/ContactService.cs
+++ b/Wino.Core/Services/ContactService.cs
@@ -52,7 +52,10 @@ namespace Wino.Core.Services
                 {
                     await Connection.InsertAsync(info).ConfigureAwait(false);
                 }
-                await Connection.InsertOrReplaceAsync(info).ConfigureAwait(false);
+                else if (!currentContact.IsRootContact) // Don't update root contacts. They belong to accounts.
+                {
+                    await Connection.InsertOrReplaceAsync(info).ConfigureAwait(false);
+                }
             }
         }
     }

--- a/Wino.Core/Services/ContactService.cs
+++ b/Wino.Core/Services/ContactService.cs
@@ -10,8 +10,8 @@ namespace Wino.Core.Services
 {
     public interface IContactService
     {
-        Task<List<AddressInformation>> GetAddressInformationAsync(string queryText);
-        Task<AddressInformation> GetAddressInformationByAddressAsync(string address);
+        Task<List<AccountContact>> GetAddressInformationAsync(string queryText);
+        Task<AccountContact> GetAddressInformationByAddressAsync(string address);
         Task SaveAddressInformationAsync(MimeMessage message);
     }
 
@@ -19,24 +19,24 @@ namespace Wino.Core.Services
     {
         public ContactService(IDatabaseService databaseService) : base(databaseService) { }
 
-        public Task<List<AddressInformation>> GetAddressInformationAsync(string queryText)
+        public Task<List<AccountContact>> GetAddressInformationAsync(string queryText)
         {
             if (queryText == null || queryText.Length < 2)
-                return Task.FromResult<List<AddressInformation>>(null);
+                return Task.FromResult<List<AccountContact>>(null);
 
-            var query = new Query(nameof(AddressInformation));
+            var query = new Query(nameof(AccountContact));
             query.WhereContains("Address", queryText);
             query.OrWhereContains("Name", queryText);
 
             var rawLikeQuery = query.GetRawQuery();
 
-            return Connection.QueryAsync<AddressInformation>(rawLikeQuery);
+            return Connection.QueryAsync<AccountContact>(rawLikeQuery);
         }
 
-        public async Task<AddressInformation> GetAddressInformationByAddressAsync(string address)
+        public async Task<AccountContact> GetAddressInformationByAddressAsync(string address)
         {
-            return await Connection.Table<AddressInformation>().Where(a => a.Address == address).FirstOrDefaultAsync()
-                ?? new AddressInformation() { Name = address, Address = address };
+            return await Connection.Table<AccountContact>().Where(a => a.Address == address).FirstOrDefaultAsync()
+                ?? new AccountContact() { Name = address, Address = address };
         }
 
         public async Task SaveAddressInformationAsync(MimeMessage message)
@@ -45,7 +45,7 @@ namespace Wino.Core.Services
                         .GetRecipients(true)
                         .Where(a => !string.IsNullOrEmpty(a.Name) && !string.IsNullOrEmpty(a.Address));
 
-            var addressInformations = recipients.Select(a => new AddressInformation() { Name = a.Name, Address = a.Address });
+            var addressInformations = recipients.Select(a => new AccountContact() { Name = a.Name, Address = a.Address });
 
             foreach (var info in addressInformations)
                 await Connection.InsertOrReplaceAsync(info).ConfigureAwait(false);

--- a/Wino.Core/Services/DatabaseService.cs
+++ b/Wino.Core/Services/DatabaseService.cs
@@ -57,7 +57,7 @@ namespace Wino.Core.Services
                 typeof(MailItemFolder),
                 typeof(MailAccount),
                 typeof(TokenInformation),
-                typeof(AddressInformation),
+                typeof(AccountContact),
                 typeof(CustomServerInformation),
                 typeof(AccountSignature),
                 typeof(MergedInbox),

--- a/Wino.Core/Services/MailService.cs
+++ b/Wino.Core/Services/MailService.cs
@@ -201,6 +201,7 @@ namespace Wino.Core.Services
 
             Dictionary<Guid, MailItemFolder> folderCache = [];
             Dictionary<Guid, MailAccount> accountCache = [];
+            Dictionary<string, AccountContact> contactCache = [];
 
             // Populate Folder Assignment for each single mail, to be able later group by "MailAccountId".
             // This is needed to execute threading strategy by account type.
@@ -255,7 +256,9 @@ namespace Wino.Core.Services
             return threadedItems;
 
             // Recursive function to populate folder and account assignments for each mail item.
-            async Task LoadAssignedPropertiesWithCacheAsync(IMailItem mail, Dictionary<Guid, MailItemFolder> folderCache, Dictionary<Guid, MailAccount> accountCache)
+            async Task LoadAssignedPropertiesWithCacheAsync(IMailItem mail,
+                                                            Dictionary<Guid, MailItemFolder> folderCache,
+                                                            Dictionary<Guid, MailAccount> accountCache)
             {
                 if (mail is ThreadMailItem threadMailItem)
                 {
@@ -276,6 +279,7 @@ namespace Wino.Core.Services
                         folderAssignment = await _folderService.GetFolderAsync(mailCopy.FolderId).ConfigureAwait(false);
                         _ = folderCache.TryAdd(mailCopy.FolderId, folderAssignment);
                     }
+
                     if (folderAssignment != null)
                     {
                         var isAccountCached = accountCache.TryGetValue(folderAssignment.MailAccountId, out accountAssignment);
@@ -283,11 +287,21 @@ namespace Wino.Core.Services
                         {
                             accountAssignment = await _accountService.GetAccountAsync(folderAssignment.MailAccountId).ConfigureAwait(false);
                             _ = accountCache.TryAdd(folderAssignment.MailAccountId, accountAssignment);
+
                         }
+                    }
+
+                    bool isContactCached = contactCache.TryGetValue(mailCopy.FromAddress, out AccountContact contactAssignment);
+
+                    if (!isContactCached && accountAssignment != null)
+                    {
+                        contactAssignment = await GetSenderContactForAccountAsync(accountAssignment, mailCopy.FromAddress).ConfigureAwait(false);
+                        _ = contactCache.TryAdd(mailCopy.FromAddress, contactAssignment);
                     }
 
                     mailCopy.AssignedFolder = folderAssignment;
                     mailCopy.AssignedAccount = accountAssignment;
+                    mailCopy.SenderContact = contactAssignment;
                 }
             }
         }
@@ -304,11 +318,23 @@ namespace Wino.Core.Services
             return mailCopies;
         }
 
+        private Task<AccountContact> GetSenderContactForAccountAsync(MailAccount account, string fromAddress)
+        {
+            if (fromAddress == account.Address)
+            {
+                return Task.FromResult(new AccountContact() { Address = account.Address, Name = account.SenderName, Base64ContactPicture = account.Base64ProfilePictureData });
+            }
+            else
+            {
+                return _contactService.GetAddressInformationByAddressAsync(fromAddress);
+            }
+        }
+
         private async Task LoadAssignedPropertiesAsync(MailCopy mailCopy)
         {
             if (mailCopy == null) return;
 
-            // Load AssignedAccount and AssignedFolder.
+            // Load AssignedAccount, AssignedFolder and SenderContact.
 
             var folder = await _folderService.GetFolderAsync(mailCopy.FolderId);
 
@@ -320,6 +346,7 @@ namespace Wino.Core.Services
 
             mailCopy.AssignedAccount = account;
             mailCopy.AssignedFolder = folder;
+            mailCopy.SenderContact = await GetSenderContactForAccountAsync(account, mailCopy.FromAddress).ConfigureAwait(false);
         }
 
         public async Task<MailCopy> GetSingleMailItemWithoutFolderAssignmentAsync(string mailCopyId)
@@ -579,6 +606,7 @@ namespace Wino.Core.Services
             mailCopy.UniqueId = Guid.NewGuid();
             mailCopy.AssignedAccount = account;
             mailCopy.AssignedFolder = assignedFolder;
+            mailCopy.SenderContact = await GetSenderContactForAccountAsync(account, mailCopy.FromAddress).ConfigureAwait(false);
             mailCopy.FolderId = assignedFolder.Id;
 
             // Only save MIME files if they don't exists.

--- a/Wino.Core/Services/MailService.cs
+++ b/Wino.Core/Services/MailService.cs
@@ -305,7 +305,7 @@ namespace Wino.Core.Services
 
                     mailCopy.AssignedFolder = folderAssignment;
                     mailCopy.AssignedAccount = accountAssignment;
-                    mailCopy.SenderContact = contactAssignment;
+                    mailCopy.SenderContact = contactAssignment ?? new AccountContact() { Name = mailCopy.FromName, Address = mailCopy.FromAddress };
                 }
             }
         }

--- a/Wino.Core/Services/MailService.cs
+++ b/Wino.Core/Services/MailService.cs
@@ -296,7 +296,11 @@ namespace Wino.Core.Services
                     if (!isContactCached && accountAssignment != null)
                     {
                         contactAssignment = await GetSenderContactForAccountAsync(accountAssignment, mailCopy.FromAddress).ConfigureAwait(false);
-                        _ = contactCache.TryAdd(mailCopy.FromAddress, contactAssignment);
+
+                        if (contactAssignment != null)
+                        {
+                            _ = contactCache.TryAdd(mailCopy.FromAddress, contactAssignment);
+                        }
                     }
 
                     mailCopy.AssignedFolder = folderAssignment;
@@ -320,6 +324,7 @@ namespace Wino.Core.Services
 
         private Task<AccountContact> GetSenderContactForAccountAsync(MailAccount account, string fromAddress)
         {
+            // Make sure to return the latest up to date contact information for the original account.
             if (fromAddress == account.Address)
             {
                 return Task.FromResult(new AccountContact() { Address = account.Address, Name = account.SenderName, Base64ContactPicture = account.Base64ProfilePictureData });

--- a/Wino.Mail.ViewModels/AppShellViewModel.cs
+++ b/Wino.Mail.ViewModels/AppShellViewModel.cs
@@ -246,7 +246,7 @@ namespace Wino.Mail.ViewModels
 
             await ForceAllAccountSynchronizationsAsync();
             await MakeSureEnableStartupLaunchAsync();
-            ConfigureBackgroundTasks();
+            await ConfigureBackgroundTasksAsync();
         }
 
         private async Task MakeSureEnableStartupLaunchAsync()
@@ -289,11 +289,14 @@ namespace Wino.Mail.ViewModels
             }
         }
 
-        private void ConfigureBackgroundTasks()
+        private async Task ConfigureBackgroundTasksAsync()
         {
             try
             {
+                // This will only unregister once. Safe to execute multiple times.
                 _backgroundTaskService.UnregisterAllBackgroundTask();
+
+                await _backgroundTaskService.RegisterBackgroundTasksAsync();
             }
             catch (Exception ex)
             {
@@ -623,7 +626,7 @@ namespace Wino.Mail.ViewModels
             }
         }
 
-        private async Task ChangeLoadedAccountAsync(IAccountMenuItem clickedBaseAccountMenuItem, bool navigateInbox = true)
+        public async Task ChangeLoadedAccountAsync(IAccountMenuItem clickedBaseAccountMenuItem, bool navigateInbox = true)
         {
             if (clickedBaseAccountMenuItem == null) return;
 

--- a/Wino.Mail.ViewModels/Collections/WinoMailCollection.cs
+++ b/Wino.Mail.ViewModels/Collections/WinoMailCollection.cs
@@ -193,7 +193,7 @@ namespace Wino.Mail.ViewModels.Collections
 
                                 if (item is MailItemViewModel itemViewModel)
                                 {
-                                    await ExecuteUIThread(() => { itemViewModel.Update(addedItem); });
+                                    await ExecuteUIThread(() => { itemViewModel.MailCopy = addedItem; });
 
                                     UpdateUniqueIdHashes(itemViewModel, false);
                                     UpdateUniqueIdHashes(addedItem, true);
@@ -230,7 +230,7 @@ namespace Wino.Mail.ViewModels.Collections
                             UpdateUniqueIdHashes(itemViewModel, false);
                             UpdateUniqueIdHashes(addedItem, true);
 
-                            await ExecuteUIThread(() => { itemViewModel.Update(addedItem); });
+                            await ExecuteUIThread(() => { itemViewModel.MailCopy = addedItem; });
 
                             shouldExit = true;
                         }
@@ -349,7 +349,10 @@ namespace Wino.Mail.ViewModels.Collections
                     UpdateUniqueIdHashes(itemContainer.ItemViewModel, false);
                 }
 
-                itemContainer.ItemViewModel?.Update(updatedMailCopy);
+                if (itemContainer.ItemViewModel != null)
+                {
+                    itemContainer.ItemViewModel.MailCopy = updatedMailCopy;
+                }
 
                 UpdateUniqueIdHashes(updatedMailCopy, true);
 

--- a/Wino.Mail.ViewModels/ComposePageViewModel.cs
+++ b/Wino.Mail.ViewModels/ComposePageViewModel.cs
@@ -85,9 +85,9 @@ namespace Wino.Mail.ViewModels
 
         public ObservableCollection<MailAttachmentViewModel> IncludedAttachments { get; set; } = [];
         public ObservableCollection<MailAccount> Accounts { get; set; } = [];
-        public ObservableCollection<AddressInformation> ToItems { get; set; } = [];
-        public ObservableCollection<AddressInformation> CCItems { get; set; } = [];
-        public ObservableCollection<AddressInformation> BCCItems { get; set; } = [];
+        public ObservableCollection<AccountContact> ToItems { get; set; } = [];
+        public ObservableCollection<AccountContact> CCItems { get; set; } = [];
+        public ObservableCollection<AccountContact> BCCItems { get; set; } = [];
 
 
         public List<EditorToolbarSection> ToolbarSections { get; set; } =
@@ -476,7 +476,7 @@ namespace Wino.Mail.ViewModels
             }
         }
 
-        private void LoadAddressInfo(InternetAddressList list, ObservableCollection<AddressInformation> collection)
+        private void LoadAddressInfo(InternetAddressList list, ObservableCollection<AccountContact> collection)
         {
             foreach (var item in list)
             {
@@ -509,7 +509,7 @@ namespace Wino.Mail.ViewModels
             }
         }
 
-        private void SaveAddressInfo(IEnumerable<AddressInformation> addresses, InternetAddressList list)
+        private void SaveAddressInfo(IEnumerable<AccountContact> addresses, InternetAddressList list)
         {
             list.Clear();
 
@@ -517,7 +517,7 @@ namespace Wino.Mail.ViewModels
                 list.Add(new MailboxAddress(item.Name, item.Address));
         }
 
-        public async Task<AddressInformation> GetAddressInformationAsync(string tokenText, ObservableCollection<AddressInformation> collection)
+        public async Task<AccountContact> GetAddressInformationAsync(string tokenText, ObservableCollection<AccountContact> collection)
         {
             // Get model from the service. This will make sure the name is properly included if there is any record.
 
@@ -550,7 +550,7 @@ namespace Wino.Mail.ViewModels
             {
                 await ExecuteUIThread(() =>
                 {
-                    CurrentMailDraftItem.Update(updatedMail);
+                    CurrentMailDraftItem.MailCopy = updatedMail;
 
                     DiscardCommand.NotifyCanExecuteChanged();
                     SendCommand.NotifyCanExecuteChanged();

--- a/Wino.Mail.ViewModels/Data/MailItemViewModel.cs
+++ b/Wino.Mail.ViewModels/Data/MailItemViewModel.cs
@@ -13,7 +13,6 @@ namespace Wino.Mail.ViewModels.Data
     {
         [ObservableProperty]
         private MailCopy mailCopy = mailCopy;
-        // public MailCopy MailCopy { get; private set; } = mailCopy;
 
         public Guid UniqueId => ((IMailItem)MailCopy).UniqueId;
         public string ThreadId => ((IMailItem)MailCopy).ThreadId;
@@ -101,21 +100,6 @@ namespace Wino.Mail.ViewModels.Data
         public Guid FileId => ((IMailItem)MailCopy).FileId;
 
         public AccountContact SenderContact => ((IMailItem)MailCopy).SenderContact;
-
-        //public void Update(MailCopy updatedMailItem)
-        //{
-        //    MailCopy = updatedMailItem;
-
-        //    //OnPropertyChanged(nameof(IsRead));
-        //    //OnPropertyChanged(nameof(IsFocused));
-        //    //OnPropertyChanged(nameof(IsFlagged));
-        //    //OnPropertyChanged(nameof(IsDraft));
-        //    //OnPropertyChanged(nameof(DraftId));
-        //    //OnPropertyChanged(nameof(Subject));
-        //    //OnPropertyChanged(nameof(PreviewText));
-        //    //OnPropertyChanged(nameof(FromAddress));
-        //    //OnPropertyChanged(nameof(HasAttachments));
-        //}
 
         public IEnumerable<Guid> GetContainingIds() => new[] { UniqueId };
     }

--- a/Wino.Mail.ViewModels/Data/MailItemViewModel.cs
+++ b/Wino.Mail.ViewModels/Data/MailItemViewModel.cs
@@ -11,12 +11,13 @@ namespace Wino.Mail.ViewModels.Data
     /// </summary>
     public partial class MailItemViewModel(MailCopy mailCopy) : ObservableObject, IMailItem
     {
-        public MailCopy MailCopy { get; private set; } = mailCopy;
+        [ObservableProperty]
+        private MailCopy mailCopy = mailCopy;
+        // public MailCopy MailCopy { get; private set; } = mailCopy;
 
         public Guid UniqueId => ((IMailItem)MailCopy).UniqueId;
         public string ThreadId => ((IMailItem)MailCopy).ThreadId;
         public string MessageId => ((IMailItem)MailCopy).MessageId;
-        public string FromName => ((IMailItem)MailCopy).FromName ?? FromAddress;
         public DateTime CreationDate => ((IMailItem)MailCopy).CreationDate;
         public string References => ((IMailItem)MailCopy).References;
         public string InReplyTo => ((IMailItem)MailCopy).InReplyTo;
@@ -31,6 +32,12 @@ namespace Wino.Mail.ViewModels.Data
         {
             get => MailCopy.IsFlagged;
             set => SetProperty(MailCopy.IsFlagged, value, MailCopy, (u, n) => u.IsFlagged = n);
+        }
+
+        public string FromName
+        {
+            get => string.IsNullOrEmpty(MailCopy.FromName) ? MailCopy.FromAddress : MailCopy.FromName;
+            set => SetProperty(MailCopy.FromName, value, MailCopy, (u, n) => u.FromName = n);
         }
 
         public bool IsFocused
@@ -93,20 +100,22 @@ namespace Wino.Mail.ViewModels.Data
 
         public Guid FileId => ((IMailItem)MailCopy).FileId;
 
-        public void Update(MailCopy updatedMailItem)
-        {
-            MailCopy = updatedMailItem;
+        public AccountContact SenderContact => ((IMailItem)MailCopy).SenderContact;
 
-            OnPropertyChanged(nameof(IsRead));
-            OnPropertyChanged(nameof(IsFocused));
-            OnPropertyChanged(nameof(IsFlagged));
-            OnPropertyChanged(nameof(IsDraft));
-            OnPropertyChanged(nameof(DraftId));
-            OnPropertyChanged(nameof(Subject));
-            OnPropertyChanged(nameof(PreviewText));
-            OnPropertyChanged(nameof(FromAddress));
-            OnPropertyChanged(nameof(HasAttachments));
-        }
+        //public void Update(MailCopy updatedMailItem)
+        //{
+        //    MailCopy = updatedMailItem;
+
+        //    //OnPropertyChanged(nameof(IsRead));
+        //    //OnPropertyChanged(nameof(IsFocused));
+        //    //OnPropertyChanged(nameof(IsFlagged));
+        //    //OnPropertyChanged(nameof(IsDraft));
+        //    //OnPropertyChanged(nameof(DraftId));
+        //    //OnPropertyChanged(nameof(Subject));
+        //    //OnPropertyChanged(nameof(PreviewText));
+        //    //OnPropertyChanged(nameof(FromAddress));
+        //    //OnPropertyChanged(nameof(HasAttachments));
+        //}
 
         public IEnumerable<Guid> GetContainingIds() => new[] { UniqueId };
     }

--- a/Wino.Mail.ViewModels/Data/ThreadMailItemViewModel.cs
+++ b/Wino.Mail.ViewModels/Data/ThreadMailItemViewModel.cs
@@ -15,6 +15,7 @@ namespace Wino.Mail.ViewModels.Data
     public partial class ThreadMailItemViewModel : ObservableObject, IMailItemThread, IComparable<string>, IComparable<DateTime>
     {
         public ObservableCollection<IMailItem> ThreadItems => ((IMailItemThread)_threadMailItem).ThreadItems;
+        public AccountContact SenderContact => ((IMailItemThread)_threadMailItem).SenderContact;
 
         private readonly ThreadMailItem _threadMailItem;
 

--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -105,6 +105,9 @@ namespace Wino.Mail.ViewModels
         private string fromName;
 
         [ObservableProperty]
+        private string contactPicture;
+
+        [ObservableProperty]
         private DateTime creationDate;
 
 
@@ -417,6 +420,7 @@ namespace Wino.Mail.ViewModels
                 FromAddress = message.From.Mailboxes.FirstOrDefault()?.Address ?? Translator.UnknownAddress;
                 FromName = message.From.Mailboxes.FirstOrDefault()?.Name ?? Translator.UnknownSender;
                 CreationDate = message.Date.DateTime;
+                ContactPicture = initializedMailItemViewModel.SenderContact?.Base64ContactPicture;
 
                 // Extract to,cc and bcc
                 await LoadAddressInfoAsync(message.To, ToItems);

--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -108,9 +108,9 @@ namespace Wino.Mail.ViewModels
         private DateTime creationDate;
 
 
-        public ObservableCollection<AddressInformation> ToItems { get; set; } = new ObservableCollection<AddressInformation>();
-        public ObservableCollection<AddressInformation> CCItemsItems { get; set; } = new ObservableCollection<AddressInformation>();
-        public ObservableCollection<AddressInformation> BCCItems { get; set; } = new ObservableCollection<AddressInformation>();
+        public ObservableCollection<AccountContact> ToItems { get; set; } = new ObservableCollection<AccountContact>();
+        public ObservableCollection<AccountContact> CCItemsItems { get; set; } = new ObservableCollection<AccountContact>();
+        public ObservableCollection<AccountContact> BCCItems { get; set; } = new ObservableCollection<AccountContact>();
         public ObservableCollection<MailAttachmentViewModel> Attachments { get; set; } = new ObservableCollection<MailAttachmentViewModel>();
         public ObservableCollection<MailOperationMenuItem> MenuItems { get; set; } = new ObservableCollection<MailOperationMenuItem>();
 
@@ -470,7 +470,7 @@ namespace Wino.Mail.ViewModels
             StatePersistenceService.IsReadingMail = false;
         }
 
-        private void LoadAddressInfo(InternetAddressList list, ObservableCollection<AddressInformation> collection)
+        private void LoadAddressInfo(InternetAddressList list, ObservableCollection<AccountContact> collection)
         {
             collection.Clear();
 

--- a/Wino.Mail.ViewModels/PersonalizationPageViewModel.cs
+++ b/Wino.Mail.ViewModels/PersonalizationPageViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wino.Core.Domain;
+using Wino.Core.Domain.Entities;
 using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Models.Personalization;
@@ -20,6 +21,14 @@ namespace Wino.Mail.ViewModels
         private readonly IThemeService _themeService;
 
         private bool isPropChangeDisabled = false;
+
+        // Sample mail copy to use in previewing mail display modes.
+        public MailCopy DemoPreviewMailCopy { get; } = new MailCopy()
+        {
+            FromName = "Sender Name",
+            Subject = "Mail Subject",
+            PreviewText = "Thank you for using Wino Mail. We hope you enjoy the experience.",
+        };
 
         #region Personalization
 

--- a/Wino.Mail/App.xaml.cs
+++ b/Wino.Mail/App.xaml.cs
@@ -304,7 +304,7 @@ namespace Wino
         {
             base.OnWindowCreated(args);
 
-            LogActivation("Window is created.");
+            LogActivation($"OnWindowCreated -> IsWindowNull: {args.Window == null}");
 
             ConfigureTitleBar();
             TryRegisterAppCloseChange();
@@ -336,7 +336,7 @@ namespace Wino
         {
             base.OnFileActivated(args);
 
-            Log.Information($"File activation for {args.Files.Count} item(s).");
+            LogActivation($"OnFileActivated -> ItemCount: {args.Files.Count}, Kind: {args.Kind}, PreviousExecutionState: {args.PreviousExecutionState}");
 
             await ActivateWinoAsync(args);
         }
@@ -356,6 +356,8 @@ namespace Wino
 
             if (args.TaskInstance.TriggerDetails is AppServiceTriggerDetails appServiceTriggerDetails)
             {
+                LogActivation("OnBackgroundActivated -> AppServiceTriggerDetails received.");
+
                 // Only accept connections from callers in the same package
                 if (appServiceTriggerDetails.CallerPackageFamilyName == Package.Current.Id.FamilyName)
                 {
@@ -372,6 +374,8 @@ namespace Wino
             else if (args.TaskInstance.TriggerDetails is ToastNotificationActionTriggerDetail toastNotificationActionTriggerDetail)
             {
                 // Notification action is triggered and the app is not running.
+
+                LogActivation("OnBackgroundActivated -> ToastNotificationActionTriggerDetail received.");
 
                 toastActionBackgroundTaskDeferral = args.TaskInstance.GetDeferral();
                 args.TaskInstance.Canceled += OnToastActionClickedBackgroundTaskCanceled;

--- a/Wino.Mail/AppShell.xaml.cs
+++ b/Wino.Mail/AppShell.xaml.cs
@@ -142,8 +142,6 @@ namespace Wino.Views
 
                 if (ViewModel.MenuItems.TryGetFolderMenuItem(message.FolderId, out IBaseFolderMenuItem foundMenuItem))
                 {
-                    if (foundMenuItem == null) return;
-
                     foundMenuItem.Expand();
 
                     await ViewModel.NavigateFolderAsync(foundMenuItem);
@@ -153,7 +151,27 @@ namespace Wino.Views
                     if (message.NavigateMailItem == null) return;
 
                     // At this point folder is navigated and items are loaded.
-                    WeakReferenceMessenger.Default.Send(new MailItemNavigationRequested(message.NavigateMailItem.UniqueId));
+                    WeakReferenceMessenger.Default.Send(new MailItemNavigationRequested(message.NavigateMailItem.UniqueId, ScrollToItem: true));
+                }
+                else if (ViewModel.MenuItems.TryGetAccountMenuItem(message.NavigateMailItem.AssignedAccount.Id, out IAccountMenuItem accountMenuItem))
+                {
+                    // Loaded account is different. First change the folder items and navigate.
+
+                    await ViewModel.ChangeLoadedAccountAsync(accountMenuItem, navigateInbox: false);
+
+                    // Find the folder.
+
+                    if (ViewModel.MenuItems.TryGetFolderMenuItem(message.FolderId, out IBaseFolderMenuItem accountFolderMenuItem))
+                    {
+                        accountFolderMenuItem.Expand();
+
+                        await ViewModel.NavigateFolderAsync(accountFolderMenuItem);
+
+                        navigationView.SelectedItem = accountFolderMenuItem;
+
+                        // At this point folder is navigated and items are loaded.
+                        WeakReferenceMessenger.Default.Send(new MailItemNavigationRequested(message.NavigateMailItem.UniqueId, ScrollToItem: true));
+                    }
                 }
             });
         }

--- a/Wino.Mail/Controls/MailItemDisplayInformationControl.xaml
+++ b/Wino.Mail/Controls/MailItemDisplayInformationControl.xaml
@@ -5,6 +5,11 @@
     xmlns:controls="using:Wino.Controls"
     xmlns:enums="using:Wino.Core.Domain.Enums"
     xmlns:domain="using:Wino.Core.Domain"
+    FocusVisualMargin="8"
+    FocusVisualPrimaryBrush="{StaticResource SystemControlRevealFocusVisualBrush}"
+    FocusVisualPrimaryThickness="2"
+    FocusVisualSecondaryBrush="{StaticResource SystemControlFocusVisualSecondaryBrush}"
+    FocusVisualSecondaryThickness="1"
     xmlns:helpers="using:Wino.Helpers"
     PointerEntered="ControlPointerEntered"
     PointerExited="ControlPointerExited">
@@ -61,8 +66,9 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     FontSize="14"
-                    FromAddress="{x:Bind FromAddress, Mode=OneWay}"
-                    FromName="{x:Bind DisplayName, Mode=OneWay}"
+                    SenderContactPicture="{x:Bind MailItem.SenderContact.Base64ContactPicture}"
+                    FromAddress="{x:Bind MailItem.FromAddress, Mode=OneWay}"
+                    FromName="{x:Bind MailItem.FromName, Mode=OneWay}"
                     Visibility="{x:Bind IsAvatarVisible, Mode=OneWay}" />
 
                 <Grid
@@ -90,7 +96,7 @@
                             <TextBlock
                                 x:Name="DraftTitle"
                                 Margin="0,0,4,0"
-                                x:Load="{x:Bind IsDraft, Mode=OneWay}"
+                                x:Load="{x:Bind MailItem.IsDraft, Mode=OneWay}"
                                 Foreground="{StaticResource DeleteBrush}">
 
                                 <Run Text="[" /><Run Text="{x:Bind domain:Translator.Draft}" /><Run Text="]" /> <Run Text=" " />
@@ -100,7 +106,7 @@
                             <TextBlock
                                 x:Name="SenderText"
                                 Grid.Column="1"
-                                Text="{x:Bind DisplayName}"
+                                Text="{x:Bind MailItem.FromName}"
                                 TextTrimming="WordEllipsis" />
 
                             <!--  Hover button  -->
@@ -148,7 +154,7 @@
                             <TextBlock
                                 x:Name="TitleText"
                                 MaxLines="1"
-                                Text="{x:Bind Subject}"
+                                Text="{x:Bind MailItem.Subject}"
                                 TextTrimming="CharacterEllipsis" />
 
                             <TextBlock
@@ -157,7 +163,7 @@
                                 VerticalAlignment="Center"
                                 FontSize="11"
                                 Opacity="0.7"
-                                Text="{x:Bind helpers:XamlHelpers.GetMailItemDisplaySummaryForListing(IsDraft, ReceivedDate, Prefer24HourTimeFormat)}" />
+                                Text="{x:Bind helpers:XamlHelpers.GetMailItemDisplaySummaryForListing(MailItem.IsDraft, MailItem.CreationDate, Prefer24HourTimeFormat)}" />
                         </Grid>
 
                         <!--  Message  -->
@@ -173,10 +179,10 @@
                             <Grid x:Name="PreviewTextContainer">
                                 <TextBlock
                                     x:Name="PreviewTextblock"
-                                    x:Load="{x:Bind helpers:XamlHelpers.ShouldDisplayPreview(Snippet), Mode=OneWay}"
+                                    x:Load="{x:Bind helpers:XamlHelpers.ShouldDisplayPreview(MailItem.PreviewText), Mode=OneWay}"
                                     MaxLines="1"
                                     Opacity="0.7"
-                                    Text="{x:Bind Snippet}"
+                                    Text="{x:Bind MailItem.PreviewText}"
                                     TextTrimming="CharacterEllipsis" />
                             </Grid>
 
@@ -190,12 +196,12 @@
 
                                 <ContentPresenter
                                     x:Name="HasAttachmentContent"
-                                    x:Load="{x:Bind HasAttachments, Mode=OneWay}"
+                                    x:Load="{x:Bind MailItem.HasAttachments, Mode=OneWay}"
                                     ContentTemplate="{StaticResource AttachmentSymbolControlTemplate}" />
 
                                 <ContentPresenter
                                     x:Name="IsFlaggedContent"
-                                    x:Load="{x:Bind IsFlagged, Mode=OneWay}"
+                                    x:Load="{x:Bind MailItem.IsFlagged, Mode=OneWay}"
                                     ContentTemplate="{StaticResource FlaggedSymbolControlTemplate}" />
                             </StackPanel>
                         </Grid>
@@ -209,7 +215,7 @@
             <VisualStateGroup x:Name="ReadStates">
                 <VisualState x:Name="Unread">
                     <VisualState.StateTriggers>
-                        <StateTrigger IsActive="{x:Bind IsRead, Converter={StaticResource ReverseBooleanConverter}, Mode=OneWay}" />
+                        <StateTrigger IsActive="{x:Bind MailItem.IsRead, Converter={StaticResource ReverseBooleanConverter}, Mode=OneWay}" />
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>

--- a/Wino.Mail/Controls/MailItemDisplayInformationControl.xaml.cs
+++ b/Wino.Mail/Controls/MailItemDisplayInformationControl.xaml.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.ComponentModel;
-using System.Numerics;
+﻿using System.Numerics;
 using System.Windows.Input;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Wino.Core.Domain.Entities;
 using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Models.MailItem;
 using Wino.Extensions;
@@ -13,22 +12,13 @@ using Wino.Mail.ViewModels.Data;
 
 namespace Wino.Controls
 {
-    public sealed partial class MailItemDisplayInformationControl : UserControl, INotifyPropertyChanged
+    public sealed partial class MailItemDisplayInformationControl : UserControl
     {
         public ImagePreviewControl GetImagePreviewControl() => ContactImage;
 
         public static readonly DependencyProperty DisplayModeProperty = DependencyProperty.Register(nameof(DisplayMode), typeof(MailListDisplayMode), typeof(MailItemDisplayInformationControl), new PropertyMetadata(MailListDisplayMode.Spacious));
         public static readonly DependencyProperty ShowPreviewTextProperty = DependencyProperty.Register(nameof(ShowPreviewText), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(true));
-        public static readonly DependencyProperty SnippetProperty = DependencyProperty.Register(nameof(Snippet), typeof(string), typeof(MailItemDisplayInformationControl), new PropertyMetadata(string.Empty));
-        public static readonly DependencyProperty FromNameProperty = DependencyProperty.Register(nameof(FromName), typeof(string), typeof(MailItemDisplayInformationControl), new PropertyMetadata(string.Empty));
-        public static readonly DependencyProperty SubjectProperty = DependencyProperty.Register(nameof(Subject), typeof(string), typeof(MailItemDisplayInformationControl), new PropertyMetadata("(no-subject)"));
-        public static readonly DependencyProperty IsReadProperty = DependencyProperty.Register(nameof(IsRead), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(false));
-        public static readonly DependencyProperty IsFlaggedProperty = DependencyProperty.Register(nameof(IsFlagged), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(false));
-        public static readonly DependencyProperty FromAddressProperty = DependencyProperty.Register(nameof(FromAddress), typeof(string), typeof(MailItemDisplayInformationControl), new PropertyMetadata(string.Empty));
-        public static readonly DependencyProperty HasAttachmentsProperty = DependencyProperty.Register(nameof(HasAttachments), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(false));
         public static readonly DependencyProperty IsCustomFocusedProperty = DependencyProperty.Register(nameof(IsCustomFocused), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(false));
-        public static readonly DependencyProperty ReceivedDateProperty = DependencyProperty.Register(nameof(ReceivedDate), typeof(DateTime), typeof(MailItemDisplayInformationControl), new PropertyMetadata(default(DateTime)));
-        public static readonly DependencyProperty IsDraftProperty = DependencyProperty.Register(nameof(IsDraft), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(false));
         public static readonly DependencyProperty IsAvatarVisibleProperty = DependencyProperty.Register(nameof(IsAvatarVisible), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(true));
         public static readonly DependencyProperty IsSubjectVisibleProperty = DependencyProperty.Register(nameof(IsSubjectVisible), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(true));
         public static readonly DependencyProperty ConnectedExpanderProperty = DependencyProperty.Register(nameof(ConnectedExpander), typeof(Expander), typeof(MailItemDisplayInformationControl), new PropertyMetadata(null));
@@ -83,8 +73,6 @@ namespace Wino.Controls
         }
 
 
-        public event PropertyChangedEventHandler PropertyChanged;
-
         public Expander ConnectedExpander
         {
             get { return (Expander)GetValue(ConnectedExpanderProperty); }
@@ -103,83 +91,10 @@ namespace Wino.Controls
             set { SetValue(IsAvatarVisibleProperty, value); }
         }
 
-        public bool IsDraft
-        {
-            get { return (bool)GetValue(IsDraftProperty); }
-            set { SetValue(IsDraftProperty, value); }
-        }
-
-        public DateTime ReceivedDate
-        {
-            get { return (DateTime)GetValue(ReceivedDateProperty); }
-            set { SetValue(ReceivedDateProperty, value); }
-        }
         public bool IsCustomFocused
         {
             get { return (bool)GetValue(IsCustomFocusedProperty); }
             set { SetValue(IsCustomFocusedProperty, value); }
-        }
-
-        public bool HasAttachments
-        {
-            get { return (bool)GetValue(HasAttachmentsProperty); }
-            set { SetValue(HasAttachmentsProperty, value); }
-        }
-
-        public bool IsRead
-        {
-            get { return (bool)GetValue(IsReadProperty); }
-            set { SetValue(IsReadProperty, value); }
-        }
-
-        public bool IsFlagged
-        {
-            get { return (bool)GetValue(IsFlaggedProperty); }
-            set { SetValue(IsFlaggedProperty, value); }
-        }
-
-        public string FromAddress
-        {
-            get { return (string)GetValue(FromAddressProperty); }
-            set
-            {
-                SetValue(FromAddressProperty, value);
-
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DisplayName)));
-            }
-        }
-
-        public string DisplayName
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(FromName))
-                    return FromAddress;
-
-                return FromName;
-            }
-        }
-        public string FromName
-        {
-            get => (string)GetValue(FromNameProperty);
-            set
-            {
-                SetValue(FromNameProperty, value);
-
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DisplayName)));
-            }
-        }
-
-        public string Subject
-        {
-            get { return (string)GetValue(SubjectProperty); }
-            set { SetValue(SubjectProperty, value); }
-        }
-
-        public string Snippet
-        {
-            get { return (string)GetValue(SnippetProperty); }
-            set { SetValue(SnippetProperty, value); }
         }
 
         public bool ShowPreviewText
@@ -234,8 +149,8 @@ namespace Wino.Controls
         {
             MailOperationPreperationRequest package = null;
 
-            if (MailItem is MailItemViewModel mailItemViewModel)
-                package = new MailOperationPreperationRequest(operation, mailItemViewModel.MailCopy, toggleExecution: true);
+            if (MailItem is MailCopy mailCopy)
+                package = new MailOperationPreperationRequest(operation, mailCopy, toggleExecution: true);
             else if (MailItem is ThreadMailItemViewModel threadMailItemViewModel)
                 package = new MailOperationPreperationRequest(operation, threadMailItemViewModel.GetMailCopies(), toggleExecution: true);
 

--- a/Wino.Mail/Views/ComposePage.xaml
+++ b/Wino.Mail/Views/ComposePage.xaml
@@ -20,7 +20,7 @@
     mc:Ignorable="d">
 
     <Page.Resources>
-        <DataTemplate x:Key="TokenBoxTemplate" x:DataType="entities:AddressInformation">
+        <DataTemplate x:Key="TokenBoxTemplate" x:DataType="entities:AccountContact">
             <Grid>
                 <ToolTipService.ToolTip>
                     <ToolTip Content="{x:Bind Address}" />
@@ -37,7 +37,7 @@
                     Text="{x:Bind Name}" />
             </Grid>
         </DataTemplate>
-        <DataTemplate x:Key="SuggestionBoxTemplate" x:DataType="entities:AddressInformation">
+        <DataTemplate x:Key="SuggestionBoxTemplate" x:DataType="entities:AccountContact">
             <Grid Margin="0,12" ColumnSpacing="6">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />

--- a/Wino.Mail/Views/ComposePage.xaml
+++ b/Wino.Mail/Views/ComposePage.xaml
@@ -22,14 +22,28 @@
     <Page.Resources>
         <DataTemplate x:Key="TokenBoxTemplate" x:DataType="entities:AccountContact">
             <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
                 <ToolTipService.ToolTip>
                     <ToolTip Content="{x:Bind Address}" />
                 </ToolTipService.ToolTip>
-                <Grid.ContextFlyout>
+
+                <!--  TODO: Display contact info.  -->
+                <!--<Grid.ContextFlyout>
                     <MenuFlyout Placement="RightEdgeAlignedBottom">
                         <MenuFlyoutItem Text="{x:Bind domain:Translator.ViewContactDetails}" />
                     </MenuFlyout>
-                </Grid.ContextFlyout>
+                </Grid.ContextFlyout>-->
+
+                <Viewbox Width="24">
+                    <controls:ImagePreviewControl
+                        SenderContactPicture="{x:Bind Base64ContactPicture}"
+                        FromAddress="{x:Bind Address}"
+                        FromName="{x:Bind Name}" />
+                </Viewbox>
+
                 <TextBlock
                     Grid.Column="1"
                     Margin="6,0,8,0"
@@ -46,6 +60,7 @@
                 <controls:ImagePreviewControl
                     FromAddress="{x:Bind Address}"
                     FromName="{x:Bind Name}"
+                    SenderContactPicture="{x:Bind Base64ContactPicture}"
                     IsKnown="False" />
                 <TextBlock Grid.Column="1">
                     <Run FontWeight="SemiBold" Text="{x:Bind Name}" /><LineBreak /><Run Text="{x:Bind Address}" />

--- a/Wino.Mail/Views/ComposePage.xaml
+++ b/Wino.Mail/Views/ComposePage.xaml
@@ -60,8 +60,7 @@
                 <controls:ImagePreviewControl
                     FromAddress="{x:Bind Address}"
                     FromName="{x:Bind Name}"
-                    SenderContactPicture="{x:Bind Base64ContactPicture}"
-                    IsKnown="False" />
+                    SenderContactPicture="{x:Bind Base64ContactPicture}" />
                 <TextBlock Grid.Column="1">
                     <Run FontWeight="SemiBold" Text="{x:Bind Name}" /><LineBreak /><Run Text="{x:Bind Address}" />
                 </TextBlock>

--- a/Wino.Mail/Views/ComposePage.xaml.cs
+++ b/Wino.Mail/Views/ComposePage.xaml.cs
@@ -574,7 +574,7 @@ namespace Wino.Views
 
             var deferal = args.GetDeferral();
 
-            AddressInformation addedItem = null;
+            AccountContact addedItem = null;
 
             var boxTag = sender.Tag?.ToString();
 
@@ -644,8 +644,8 @@ namespace Wino.Views
                 {
                     var boxTag = tokenizingTextBox.Tag?.ToString();
 
-                    AddressInformation addedItem = null;
-                    ObservableCollection<AddressInformation> addressCollection = null;
+                    AccountContact addedItem = null;
+                    ObservableCollection<AccountContact> addressCollection = null;
 
                     if (boxTag == "ToBox")
                         addressCollection = ViewModel.ToItems;

--- a/Wino.Mail/Views/MailListPage.xaml
+++ b/Wino.Mail/Views/MailListPage.xaml
@@ -118,29 +118,15 @@
                 CenterHoverAction="{Binding ElementName=root, Path=ViewModel.PreferencesService.CenterHoverAction, Mode=OneWay}"
                 ContextRequested="MailItemContextRequested"
                 DisplayMode="{Binding ElementName=root, Path=ViewModel.PreferencesService.MailItemDisplayMode, Mode=OneWay}"
-                FocusVisualMargin="8"
-                FocusVisualPrimaryBrush="{StaticResource SystemControlRevealFocusVisualBrush}"
-                FocusVisualPrimaryThickness="2"
-                FocusVisualSecondaryBrush="{StaticResource SystemControlFocusVisualSecondaryBrush}"
-                FocusVisualSecondaryThickness="1"
-                FromAddress="{x:Bind FromAddress}"
-                FromName="{x:Bind FromName}"
-                HasAttachments="{x:Bind HasAttachments}"
                 HoverActionExecutedCommand="{Binding ElementName=root, Path=ViewModel.ExecuteHoverActionCommand}"
                 IsAvatarVisible="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowSenderPicturesEnabled, Mode=OneWay}"
                 IsCustomFocused="{x:Bind IsCustomFocused, Mode=OneWay}"
-                IsDraft="{x:Bind IsDraft, Mode=OneWay}"
-                IsFlagged="{x:Bind IsFlagged, Mode=OneWay}"
                 IsHoverActionsEnabled="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsHoverActionsEnabled, Mode=OneWay}"
-                IsRead="{x:Bind IsRead, Mode=OneWay}"
                 LeftHoverAction="{Binding ElementName=root, Path=ViewModel.PreferencesService.LeftHoverAction, Mode=OneWay}"
-                MailItem="{Binding}"
+                MailItem="{x:Bind MailCopy, Mode=OneWay}"
                 Prefer24HourTimeFormat="{Binding ElementName=root, Path=ViewModel.PreferencesService.Prefer24HourTimeFormat, Mode=OneWay}"
-                ReceivedDate="{x:Bind CreationDate}"
                 RightHoverAction="{Binding ElementName=root, Path=ViewModel.PreferencesService.RightHoverAction, Mode=OneWay}"
-                ShowPreviewText="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowPreviewEnabled, Mode=OneWay}"
-                Snippet="{x:Bind PreviewText}"
-                Subject="{x:Bind Subject}" />
+                ShowPreviewText="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowPreviewEnabled, Mode=OneWay}" />
         </DataTemplate>
 
         <!--  Single Mail Item Template for Threads  -->
@@ -155,24 +141,15 @@
                 FocusVisualPrimaryThickness="2"
                 FocusVisualSecondaryBrush="{StaticResource SystemControlFocusVisualSecondaryBrush}"
                 FocusVisualSecondaryThickness="1"
-                FromAddress="{x:Bind FromAddress}"
-                FromName="{x:Bind FromName}"
-                HasAttachments="{x:Bind HasAttachments}"
                 HoverActionExecutedCommand="{Binding ElementName=root, Path=ViewModel.ExecuteHoverActionCommand}"
                 IsAvatarVisible="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowSenderPicturesEnabled, Mode=OneWay}"
                 IsCustomFocused="{x:Bind IsCustomFocused, Mode=OneWay}"
-                IsDraft="{x:Bind IsDraft, Mode=OneWay}"
-                IsFlagged="{x:Bind IsFlagged, Mode=OneWay}"
                 IsHoverActionsEnabled="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsHoverActionsEnabled, Mode=OneWay}"
-                IsRead="{x:Bind IsRead, Mode=OneWay}"
                 LeftHoverAction="{Binding ElementName=root, Path=ViewModel.PreferencesService.LeftHoverAction, Mode=OneWay}"
-                MailItem="{Binding}"
+                MailItem="{x:Bind MailCopy, Mode=OneWay}"
                 Prefer24HourTimeFormat="{Binding ElementName=root, Path=ViewModel.PreferencesService.Prefer24HourTimeFormat, Mode=OneWay}"
-                ReceivedDate="{x:Bind CreationDate}"
                 RightHoverAction="{Binding ElementName=root, Path=ViewModel.PreferencesService.RightHoverAction, Mode=OneWay}"
-                ShowPreviewText="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowPreviewEnabled, Mode=OneWay}"
-                Snippet="{x:Bind PreviewText}"
-                Subject="{x:Bind Subject}" />
+                ShowPreviewText="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowPreviewEnabled, Mode=OneWay}" />
         </DataTemplate>
 
         <!--  Mail Item Content Selector  -->
@@ -199,24 +176,15 @@
                                 DisplayMode="{Binding ElementName=root, Path=ViewModel.PreferencesService.MailItemDisplayMode, Mode=OneWay}"
                                 DragStarting="ThreadHeaderDragStart"
                                 DropCompleted="ThreadHeaderDragFinished"
-                                FromAddress="{x:Bind FromAddress}"
-                                FromName="{x:Bind FromName}"
-                                HasAttachments="{x:Bind HasAttachments}"
                                 HoverActionExecutedCommand="{Binding ElementName=root, Path=ViewModel.ExecuteHoverActionCommand}"
                                 IsAvatarVisible="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowSenderPicturesEnabled, Mode=OneWay}"
-                                IsDraft="{x:Bind IsDraft}"
-                                IsFlagged="{x:Bind IsFlagged}"
                                 IsHitTestVisible="True"
                                 IsHoverActionsEnabled="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsHoverActionsEnabled, Mode=OneWay}"
-                                IsRead="{x:Bind IsRead}"
                                 LeftHoverAction="{Binding ElementName=root, Path=ViewModel.PreferencesService.LeftHoverAction, Mode=OneWay}"
-                                MailItem="{Binding}"
+                                MailItem="{Binding Mode=OneWay}"
                                 Prefer24HourTimeFormat="{Binding ElementName=root, Path=ViewModel.PreferencesService.Prefer24HourTimeFormat, Mode=OneWay}"
-                                ReceivedDate="{x:Bind CreationDate}"
                                 RightHoverAction="{Binding ElementName=root, Path=ViewModel.PreferencesService.RightHoverAction, Mode=OneWay}"
-                                ShowPreviewText="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowPreviewEnabled, Mode=OneWay}"
-                                Snippet="{x:Bind PreviewText}"
-                                Subject="{x:Bind Subject}" />
+                                ShowPreviewText="{Binding ElementName=root, Path=ViewModel.PreferencesService.IsShowPreviewEnabled, Mode=OneWay}" />
                         </muxc:Expander.Header>
                         <muxc:Expander.Content>
                             <listview:WinoListView

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -252,73 +252,88 @@
                         </Grid>
                     </CommandBar.Content>
                 </CommandBar>
+
                 <Grid
+                    x:Name="ToFromInformationPanel"
                     Grid.Row="2"
                     Margin="5,2,0,0"
-                    RowSpacing="4">
+                    RowSpacing="6">
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <StackPanel
-                        x:Name="ToFromInformationPanel"
-                        Orientation="Vertical"
-                        Spacing="6">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock
-                                VerticalAlignment="Center"
-                                FontWeight="SemiBold"
-                                Text="{x:Bind domain:Translator.ComposerTo}"
-                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}" />
-                            <ItemsControl
-                                ItemTemplate="{StaticResource InternetAddressTemplate}"
-                                ItemsSource="{x:Bind ViewModel.ToItems, Mode=OneWay}"
-                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}">
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <ItemsStackPanel Orientation="Horizontal" />
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
-                        </StackPanel>
+                    <Grid ColumnSpacing="6">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
 
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock
-                                VerticalAlignment="Center"
-                                FontWeight="SemiBold"
-                                Text="Cc:"
-                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CCItemsItems.Count), Mode=OneWay}" />
-                            <ItemsControl
-                                ItemTemplate="{StaticResource InternetAddressTemplate}"
-                                ItemsSource="{x:Bind ViewModel.CCItemsItems, Mode=OneWay}"
-                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CCItemsItems.Count), Mode=OneWay}">
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <ItemsStackPanel Orientation="Horizontal" />
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
-                        </StackPanel>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontWeight="SemiBold"
+                            Text="{x:Bind domain:Translator.ComposerTo}"
+                            Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}" />
 
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock
-                                VerticalAlignment="Center"
-                                FontWeight="SemiBold"
-                                Text="Bcc:"
-                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BCCItems.Count), Mode=OneWay}" />
-                            <ItemsControl
-                                ItemTemplate="{StaticResource InternetAddressTemplate}"
-                                ItemsSource="{x:Bind ViewModel.BCCItems, Mode=OneWay}"
-                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BCCItems.Count), Mode=OneWay}">
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <ItemsStackPanel Orientation="Horizontal" />
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
-                        </StackPanel>
-                    </StackPanel>
+                        <ItemsControl
+                            Grid.Column="1"
+                            ItemTemplate="{StaticResource InternetAddressTemplate}"
+                            ItemsSource="{x:Bind ViewModel.ToItems, Mode=OneWay}"
+                            Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <ItemsWrapGrid Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                    </Grid>
+                    <Grid ColumnSpacing="6" Grid.Row="1">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontWeight="SemiBold"
+                            Text="Cc:"
+                            Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CCItemsItems.Count), Mode=OneWay}" />
+                        <ItemsControl
+                            Grid.Column="1"
+                            ItemTemplate="{StaticResource InternetAddressTemplate}"
+                            ItemsSource="{x:Bind ViewModel.CCItemsItems, Mode=OneWay}"
+                            Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CCItemsItems.Count), Mode=OneWay}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <ItemsWrapGrid Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                    </Grid>
+                    <Grid Grid.Row="2" ColumnSpacing="6">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontWeight="SemiBold"
+                            Text="Bcc:"
+                            Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BCCItems.Count), Mode=OneWay}" />
+
+                        <ItemsControl
+                            Grid.Column="1"
+                            ItemTemplate="{StaticResource InternetAddressTemplate}"
+                            ItemsSource="{x:Bind ViewModel.BCCItems, Mode=OneWay}"
+                            Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BCCItems.Count), Mode=OneWay}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <ItemsWrapGrid Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                    </Grid>
                 </Grid>
 
                 <!--  Attachments  -->

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -1,59 +1,63 @@
-﻿<abstract:MailRenderingPageAbstract x:Class="Wino.Views.MailRenderingPage"
-                                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                    xmlns:abstract="using:Wino.Views.Abstract"
-                                    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-                                    xmlns:controls1="using:Wino.Controls"
-                                    xmlns:controls2="using:CommunityToolkit.WinUI.Controls"
-                                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                    xmlns:domain="using:Wino.Core.Domain"
-                                    xmlns:entities="using:Wino.Core.Domain.Entities"
-                                    xmlns:helpers="using:Wino.Helpers"
-                                    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-                                    xmlns:local="using:Wino.Behaviors"
-                                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                                    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-                                    xmlns:selectors="using:Wino.Selectors"
-                                    xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
-                                    xmlns:viewModelData="using:Wino.Mail.ViewModels.Data"
-                                    x:Name="root"
-                                    muxc:BackdropMaterial.ApplyToRootOrPageBackground="{ThemeResource UseMica}"
-                                    IsDarkEditor="{x:Bind ViewModel.IsDarkWebviewRenderer, Mode=TwoWay}"
-                                    mc:Ignorable="d">
+﻿<abstract:MailRenderingPageAbstract
+    x:Class="Wino.Views.MailRenderingPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:abstract="using:Wino.Views.Abstract"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:controls1="using:Wino.Controls"
+    xmlns:controls2="using:CommunityToolkit.WinUI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:domain="using:Wino.Core.Domain"
+    xmlns:entities="using:Wino.Core.Domain.Entities"
+    xmlns:helpers="using:Wino.Helpers"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:local="using:Wino.Behaviors"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:selectors="using:Wino.Selectors"
+    xmlns:ui="using:Microsoft.Toolkit.Uwp.UI"
+    xmlns:viewModelData="using:Wino.Mail.ViewModels.Data"
+    x:Name="root"
+    muxc:BackdropMaterial.ApplyToRootOrPageBackground="{ThemeResource UseMica}"
+    IsDarkEditor="{x:Bind ViewModel.IsDarkWebviewRenderer, Mode=TwoWay}"
+    mc:Ignorable="d">
 
     <Page.Resources>
         <!--  The Layout specifications used:  -->
-        <controls:StackLayout x:Name="HorizontalStackLayout"
-                              Orientation="Horizontal"
-                              Spacing="8" />
+        <controls:StackLayout
+            x:Name="HorizontalStackLayout"
+            Orientation="Horizontal"
+            Spacing="8" />
 
-        <DataTemplate x:Key="InternetAddressTemplate" x:DataType="entities:AddressInformation">
-            <HyperlinkButton Padding="2"
-                             Command="{Binding ElementName=root, Path=ViewModel.CopyClipboardCommand}"
-                             CommandParameter="{x:Bind Address}"
-                             Content="{x:Bind DisplayName}" />
+        <DataTemplate x:Key="InternetAddressTemplate" x:DataType="entities:AccountContact">
+            <HyperlinkButton
+                Padding="2"
+                Command="{Binding ElementName=root, Path=ViewModel.CopyClipboardCommand}"
+                CommandParameter="{x:Bind Address}"
+                Content="{x:Bind DisplayName}" />
         </DataTemplate>
 
-        <selectors:RendererCommandBarItemTemplateSelector x:Key="RendererCommandBarItemTemplateSelector"
-                                                          Archive="{StaticResource CommandBarItemArchiveTemplate}"
-                                                          ClearFlag="{StaticResource CommandBarItemClearFlagTemplate}"
-                                                          DarkEditor="{StaticResource CommandBarItemDarkEditorTemplate}"
-                                                          Delete="{StaticResource CommandBarItemDeleteTemplate}"
-                                                          Find="{StaticResource CommandBarItemFindTemplate}"
-                                                          Forward="{StaticResource CommandBarItemForwardTemplate}"
-                                                          LightEditor="{StaticResource CommandBarItemLightEditorTemplate}"
-                                                          MarkAsRead="{StaticResource CommandBarItemMarkReadTemplate}"
-                                                          MarkAsUnread="{StaticResource CommandBarItemMarkUnreadTemplate}"
-                                                          Move="{StaticResource CommandBarItemMoveTemplate}"
-                                                          MoveToJunk="{StaticResource CommandBarItemMoveToJunkTemplate}"
-                                                          Print="{StaticResource CommandBarItemPrintTemplate}"
-                                                          Reply="{StaticResource CommandBarItemReplyTemplate}"
-                                                          ReplyAll="{StaticResource CommandBarItemReplyAllTemplate}"
-                                                          SaveAs="{StaticResource CommandBarItemSaveTemplate}"
-                                                          SeperatorTemplate="{StaticResource CommandBarItemSeperatorTemplate}"
-                                                          SetFlag="{StaticResource CommandBarItemSetFlagTemplate}"
-                                                          Unarchive="{StaticResource CommandBarItemUnarchiveTemplate}"
-                                                          Zoom="{StaticResource CommandBarItemZoomTemplate}" />
+        <selectors:RendererCommandBarItemTemplateSelector
+            x:Key="RendererCommandBarItemTemplateSelector"
+            Archive="{StaticResource CommandBarItemArchiveTemplate}"
+            ClearFlag="{StaticResource CommandBarItemClearFlagTemplate}"
+            DarkEditor="{StaticResource CommandBarItemDarkEditorTemplate}"
+            Delete="{StaticResource CommandBarItemDeleteTemplate}"
+            Find="{StaticResource CommandBarItemFindTemplate}"
+            Forward="{StaticResource CommandBarItemForwardTemplate}"
+            LightEditor="{StaticResource CommandBarItemLightEditorTemplate}"
+            MarkAsRead="{StaticResource CommandBarItemMarkReadTemplate}"
+            MarkAsUnread="{StaticResource CommandBarItemMarkUnreadTemplate}"
+            Move="{StaticResource CommandBarItemMoveTemplate}"
+            MoveToJunk="{StaticResource CommandBarItemMoveToJunkTemplate}"
+            Print="{StaticResource CommandBarItemPrintTemplate}"
+            Reply="{StaticResource CommandBarItemReplyTemplate}"
+            ReplyAll="{StaticResource CommandBarItemReplyAllTemplate}"
+            SaveAs="{StaticResource CommandBarItemSaveTemplate}"
+            SeperatorTemplate="{StaticResource CommandBarItemSeperatorTemplate}"
+            SetFlag="{StaticResource CommandBarItemSetFlagTemplate}"
+            Unarchive="{StaticResource CommandBarItemUnarchiveTemplate}"
+            Zoom="{StaticResource CommandBarItemZoomTemplate}" />
 
         <!--  Attachment Template  -->
         <!--  Margin -8 0 is used to remove the padding from the ListViewItem  -->
@@ -63,26 +67,29 @@
                     <RowDefinition Height="50" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <Grid Grid.Row="0"
-                      Height="50"
-                      Margin="-8,0,0,0"
-                      Background="Transparent"
-                      ColumnSpacing="3">
+                <Grid
+                    Grid.Row="0"
+                    Height="50"
+                    Margin="-8,0,0,0"
+                    Background="Transparent"
+                    ColumnSpacing="3">
                     <ToolTipService.ToolTip>
                         <ToolTip Content="{x:Bind FileName}" />
                     </ToolTipService.ToolTip>
                     <Grid.ContextFlyout>
                         <MenuFlyout Placement="Right">
-                            <MenuFlyoutItem Command="{Binding ElementName=root, Path=ViewModel.OpenAttachmentCommand}"
-                                            CommandParameter="{x:Bind}"
-                                            Text="{x:Bind domain:Translator.Buttons_Open}">
+                            <MenuFlyoutItem
+                                Command="{Binding ElementName=root, Path=ViewModel.OpenAttachmentCommand}"
+                                CommandParameter="{x:Bind}"
+                                Text="{x:Bind domain:Translator.Buttons_Open}">
                                 <MenuFlyoutItem.Icon>
                                     <PathIcon Data="{StaticResource OpenFilePathIcon}" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
-                            <MenuFlyoutItem Command="{Binding ElementName=root, Path=ViewModel.SaveAttachmentCommand}"
-                                            CommandParameter="{x:Bind}"
-                                            Text="{x:Bind domain:Translator.Buttons_Save}">
+                            <MenuFlyoutItem
+                                Command="{Binding ElementName=root, Path=ViewModel.SaveAttachmentCommand}"
+                                CommandParameter="{x:Bind}"
+                                Text="{x:Bind domain:Translator.Buttons_Save}">
                                 <MenuFlyoutItem.Icon>
                                     <PathIcon Data="{StaticResource SaveAttachmentPathIcon}" />
                                 </MenuFlyoutItem.Icon>
@@ -95,41 +102,46 @@
                     </Grid.ColumnDefinitions>
 
                     <!--  Icon  -->
-                    <ContentControl VerticalAlignment="Center"
-                                    Content="{x:Bind AttachmentType}"
-                                    ContentTemplateSelector="{StaticResource FileTypeIconSelector}" />
+                    <ContentControl
+                        VerticalAlignment="Center"
+                        Content="{x:Bind AttachmentType}"
+                        ContentTemplateSelector="{StaticResource FileTypeIconSelector}" />
 
                     <!--  Name && Size  -->
-                    <Grid Grid.Column="1"
-                          MaxWidth="200"
-                          VerticalAlignment="Center">
+                    <Grid
+                        Grid.Column="1"
+                        MaxWidth="200"
+                        VerticalAlignment="Center">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
-                        <TextBlock FontSize="13"
-                                   MaxLines="1"
-                                   Text="{x:Bind FileName}"
-                                   TextTrimming="CharacterEllipsis"
-                                   TextWrapping="Wrap" />
+                        <TextBlock
+                            FontSize="13"
+                            MaxLines="1"
+                            Text="{x:Bind FileName}"
+                            TextTrimming="CharacterEllipsis"
+                            TextWrapping="Wrap" />
 
-                        <TextBlock Grid.Row="1"
-                                   HorizontalAlignment="Right"
-                                   VerticalAlignment="Bottom"
-                                   FontSize="11"
-                                   Foreground="Gray"
-                                   Text="{x:Bind ReadableSize}" />
+                        <TextBlock
+                            Grid.Row="1"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            FontSize="11"
+                            Foreground="Gray"
+                            Text="{x:Bind ReadableSize}" />
                     </Grid>
                 </Grid>
-                <muxc:ProgressBar Grid.Row="1"
-                                  Margin="0,-5,0,0"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Top"
-                                  IsIndeterminate="{x:Bind IsBusy, Mode=OneWay}"
-                                  ShowError="False"
-                                  ShowPaused="False"
-                                  Visibility="{x:Bind IsBusy, Mode=OneWay}" />
+                <muxc:ProgressBar
+                    Grid.Row="1"
+                    Margin="0,-5,0,0"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Top"
+                    IsIndeterminate="{x:Bind IsBusy, Mode=OneWay}"
+                    ShowError="False"
+                    ShowPaused="False"
+                    Visibility="{x:Bind IsBusy, Mode=OneWay}" />
             </Grid>
 
         </DataTemplate>
@@ -137,18 +149,20 @@
     </Page.Resources>
 
     <!--  Attachments and WebView2  -->
-    <Grid x:Name="RendererGridFrame"
-          Padding="7,0"
-          RowSpacing="7">
+    <Grid
+        x:Name="RendererGridFrame"
+        Padding="7,0"
+        RowSpacing="7">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Border Background="{ThemeResource WinoContentZoneBackgroud}"
-                BorderBrush="{StaticResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="7">
+        <Border
+            Background="{ThemeResource WinoContentZoneBackgroud}"
+            BorderBrush="{StaticResource CardStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="7">
             <Grid Margin="8,8,8,0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -163,35 +177,40 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock VerticalAlignment="Center"
-                               FontSize="18"
-                               FontWeight="SemiBold"
-                               Text="{x:Bind ViewModel.Subject, Mode=OneWay}"
-                               TextWrapping="Wrap" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        FontSize="18"
+                        FontWeight="SemiBold"
+                        Text="{x:Bind ViewModel.Subject, Mode=OneWay}"
+                        TextWrapping="Wrap" />
 
-                    <HyperlinkButton Grid.Column="1"
-                                     Margin="0,0,3,0"
-                                     Command="{x:Bind ViewModel.UnsubscribeCommand}"
-                                     Visibility="{x:Bind ViewModel.CanUnsubscribe, Mode=OneWay}">
+                    <HyperlinkButton
+                        Grid.Column="1"
+                        Margin="0,0,3,0"
+                        Command="{x:Bind ViewModel.UnsubscribeCommand}"
+                        Visibility="{x:Bind ViewModel.CanUnsubscribe, Mode=OneWay}">
                         <StackPanel Orientation="Horizontal" Spacing="6">
-                            <PathIcon HorizontalAlignment="Center"
-                                      VerticalAlignment="Center"
-                                      Data="F1 M 3.75 4.902344 C 3.75 4.225262 3.885091 3.588867 4.155273 2.993164 C 4.425456 2.397461 4.790039 1.878256 5.249023 1.435547 C 5.708008 0.99284 6.238606 0.642904 6.84082 0.385742 C 7.443034 0.128582 8.079427 0 8.75 0 C 9.420572 0 10.056966 0.128582 10.65918 0.385742 C 11.261393 0.642904 11.791992 0.99284 12.250977 1.435547 C 12.709961 1.878256 13.074544 2.397461 13.344727 2.993164 C 13.614908 3.588867 13.75 4.225262 13.75 4.902344 C 13.75 5.332031 13.707682 5.740561 13.623047 6.12793 C 13.538411 6.5153 13.395182 6.901042 13.193359 7.285156 C 12.307942 7.434896 11.484375 7.734375 10.722656 8.183594 C 11.295572 7.819012 11.735025 7.353517 12.041016 6.787109 C 12.347005 6.220704 12.5 5.598959 12.5 4.921875 C 12.5 4.414062 12.399088 3.937176 12.197266 3.491211 C 11.995442 3.045248 11.722005 2.65625 11.376953 2.324219 C 11.0319 1.992188 10.633138 1.730145 10.180664 1.538086 C 9.728189 1.346029 9.251302 1.25 8.75 1.25 C 8.229166 1.25 7.740885 1.347656 7.285156 1.542969 C 6.829427 1.738281 6.432292 2.005209 6.09375 2.34375 C 5.755208 2.682293 5.488281 3.079428 5.292969 3.535156 C 5.097656 3.990887 5 4.479167 5 5 C 5 5.501303 5.096028 5.97819 5.288086 6.430664 C 5.480143 6.883139 5.742188 7.281902 6.074219 7.626953 C 6.40625 7.972006 6.795247 8.245443 7.241211 8.447266 C 7.687174 8.649089 8.164062 8.75 8.671875 8.75 C 9.029947 8.75 9.368489 8.710938 9.6875 8.632812 C 10.00651 8.554688 10.322266 8.424479 10.634766 8.242188 C 9.873047 8.704428 9.222005 9.290365 8.681641 10 L 8.662109 10 C 8.011067 10 7.389323 9.868164 6.796875 9.604492 C 6.204427 9.34082 5.681966 8.984375 5.229492 8.535156 C 4.777018 8.085938 4.417317 7.565104 4.150391 6.972656 C 3.883463 6.380209 3.75 5.755209 3.75 5.097656 Z M 8.75 14.375 C 8.75 13.600261 8.898111 12.871094 9.194336 12.1875 C 9.49056 11.503906 9.892578 10.908203 10.400391 10.400391 C 10.908203 9.892578 11.503906 9.490561 12.1875 9.194336 C 12.871093 8.898112 13.60026 8.75 14.375 8.75 C 14.889322 8.75 15.385741 8.816732 15.864258 8.950195 C 16.342773 9.083659 16.790363 9.272461 17.207031 9.516602 C 17.623697 9.760742 18.004557 10.055339 18.349609 10.400391 C 18.69466 10.745443 18.989258 11.126303 19.233398 11.542969 C 19.477539 11.959636 19.66634 12.407227 19.799805 12.885742 C 19.933268 13.364258 20 13.860678 20 14.375 C 20 15.14974 19.851887 15.878906 19.555664 16.5625 C 19.259439 17.246094 18.857422 17.841797 18.349609 18.349609 C 17.841797 18.857422 17.246094 19.259439 16.5625 19.555664 C 15.878906 19.851889 15.149739 20 14.375 20 C 13.59375 20 12.861328 19.853516 12.177734 19.560547 C 11.494141 19.267578 10.898438 18.867188 10.390625 18.359375 C 9.882812 17.851562 9.482422 17.255859 9.189453 16.572266 C 8.896484 15.888672 8.75 15.15625 8.75 14.375 Z M 0 13.701172 C 0 13.375651 0.066732 13.064779 0.200195 12.768555 C 0.333659 12.472331 0.512695 12.211914 0.737305 11.987305 C 0.961914 11.762695 1.222331 11.583659 1.518555 11.450195 C 1.814779 11.316732 2.125651 11.25 2.451172 11.25 L 7.900391 11.25 C 7.809244 11.451823 7.722981 11.656901 7.641602 11.865234 C 7.560221 12.073568 7.490234 12.285156 7.431641 12.5 L 2.5 12.5 C 2.324219 12.5 2.161458 12.532553 2.011719 12.597656 C 1.861979 12.662761 1.730143 12.752279 1.616211 12.866211 C 1.502279 12.980144 1.41276 13.111979 1.347656 13.261719 C 1.282552 13.411459 1.25 13.574219 1.25 13.75 C 1.25 14.407553 1.359049 14.986979 1.577148 15.488281 C 1.795247 15.989584 2.091471 16.425781 2.46582 16.796875 C 2.840169 17.167969 3.273112 17.478842 3.764648 17.729492 C 4.256185 17.980143 4.777018 18.180338 5.327148 18.330078 C 5.877278 18.479818 6.438802 18.58724 7.011719 18.652344 C 7.584635 18.717447 8.138021 18.75 8.671875 18.75 C 8.847656 18.977865 9.033203 19.192709 9.228516 19.394531 C 9.423828 19.596354 9.635416 19.785156 9.863281 19.960938 C 9.674479 19.973959 9.488932 19.983725 9.306641 19.990234 C 9.124349 19.996744 8.938802 20 8.75 20 C 8.333333 20 7.908528 19.986979 7.475586 19.960938 C 7.042643 19.934896 6.612955 19.887695 6.186523 19.819336 C 5.760091 19.750977 5.340169 19.65983 4.926758 19.545898 C 4.513346 19.431967 4.114583 19.287109 3.730469 19.111328 C 3.157552 18.850912 2.641602 18.543295 2.182617 18.188477 C 1.723633 17.833658 1.333008 17.431641 1.010742 16.982422 C 0.688477 16.533203 0.439453 16.035156 0.263672 15.488281 C 0.087891 14.941406 0 14.345703 0 13.701172 Z M 14.375 15.253906 L 16.123047 17.001953 C 16.246744 17.12565 16.393229 17.1875 16.5625 17.1875 C 16.73177 17.1875 16.878254 17.12565 17.001953 17.001953 C 17.12565 16.878256 17.1875 16.731771 17.1875 16.5625 C 17.1875 16.39323 17.12565 16.246746 17.001953 16.123047 L 15.263672 14.375 L 17.001953 12.626953 C 17.12565 12.503256 17.1875 12.356771 17.1875 12.1875 C 17.1875 12.018229 17.12565 11.871745 17.001953 11.748047 C 16.878254 11.62435 16.73177 11.5625 16.5625 11.5625 C 16.393229 11.5625 16.246744 11.62435 16.123047 11.748047 L 14.375 13.486328 L 12.626953 11.748047 C 12.503255 11.62435 12.356771 11.5625 12.1875 11.5625 C 12.018229 11.5625 11.871744 11.62435 11.748047 11.748047 C 11.624349 11.871745 11.5625 12.018229 11.5625 12.1875 C 11.5625 12.356771 11.624349 12.503256 11.748047 12.626953 L 13.496094 14.375 L 11.748047 16.123047 C 11.624349 16.246746 11.5625 16.39323 11.5625 16.5625 C 11.5625 16.731771 11.624349 16.878256 11.748047 17.001953 C 11.871744 17.12565 12.018229 17.1875 12.1875 17.1875 C 12.356771 17.1875 12.503255 17.12565 12.626953 17.001953 Z " />
+                            <PathIcon
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Data="F1 M 3.75 4.902344 C 3.75 4.225262 3.885091 3.588867 4.155273 2.993164 C 4.425456 2.397461 4.790039 1.878256 5.249023 1.435547 C 5.708008 0.99284 6.238606 0.642904 6.84082 0.385742 C 7.443034 0.128582 8.079427 0 8.75 0 C 9.420572 0 10.056966 0.128582 10.65918 0.385742 C 11.261393 0.642904 11.791992 0.99284 12.250977 1.435547 C 12.709961 1.878256 13.074544 2.397461 13.344727 2.993164 C 13.614908 3.588867 13.75 4.225262 13.75 4.902344 C 13.75 5.332031 13.707682 5.740561 13.623047 6.12793 C 13.538411 6.5153 13.395182 6.901042 13.193359 7.285156 C 12.307942 7.434896 11.484375 7.734375 10.722656 8.183594 C 11.295572 7.819012 11.735025 7.353517 12.041016 6.787109 C 12.347005 6.220704 12.5 5.598959 12.5 4.921875 C 12.5 4.414062 12.399088 3.937176 12.197266 3.491211 C 11.995442 3.045248 11.722005 2.65625 11.376953 2.324219 C 11.0319 1.992188 10.633138 1.730145 10.180664 1.538086 C 9.728189 1.346029 9.251302 1.25 8.75 1.25 C 8.229166 1.25 7.740885 1.347656 7.285156 1.542969 C 6.829427 1.738281 6.432292 2.005209 6.09375 2.34375 C 5.755208 2.682293 5.488281 3.079428 5.292969 3.535156 C 5.097656 3.990887 5 4.479167 5 5 C 5 5.501303 5.096028 5.97819 5.288086 6.430664 C 5.480143 6.883139 5.742188 7.281902 6.074219 7.626953 C 6.40625 7.972006 6.795247 8.245443 7.241211 8.447266 C 7.687174 8.649089 8.164062 8.75 8.671875 8.75 C 9.029947 8.75 9.368489 8.710938 9.6875 8.632812 C 10.00651 8.554688 10.322266 8.424479 10.634766 8.242188 C 9.873047 8.704428 9.222005 9.290365 8.681641 10 L 8.662109 10 C 8.011067 10 7.389323 9.868164 6.796875 9.604492 C 6.204427 9.34082 5.681966 8.984375 5.229492 8.535156 C 4.777018 8.085938 4.417317 7.565104 4.150391 6.972656 C 3.883463 6.380209 3.75 5.755209 3.75 5.097656 Z M 8.75 14.375 C 8.75 13.600261 8.898111 12.871094 9.194336 12.1875 C 9.49056 11.503906 9.892578 10.908203 10.400391 10.400391 C 10.908203 9.892578 11.503906 9.490561 12.1875 9.194336 C 12.871093 8.898112 13.60026 8.75 14.375 8.75 C 14.889322 8.75 15.385741 8.816732 15.864258 8.950195 C 16.342773 9.083659 16.790363 9.272461 17.207031 9.516602 C 17.623697 9.760742 18.004557 10.055339 18.349609 10.400391 C 18.69466 10.745443 18.989258 11.126303 19.233398 11.542969 C 19.477539 11.959636 19.66634 12.407227 19.799805 12.885742 C 19.933268 13.364258 20 13.860678 20 14.375 C 20 15.14974 19.851887 15.878906 19.555664 16.5625 C 19.259439 17.246094 18.857422 17.841797 18.349609 18.349609 C 17.841797 18.857422 17.246094 19.259439 16.5625 19.555664 C 15.878906 19.851889 15.149739 20 14.375 20 C 13.59375 20 12.861328 19.853516 12.177734 19.560547 C 11.494141 19.267578 10.898438 18.867188 10.390625 18.359375 C 9.882812 17.851562 9.482422 17.255859 9.189453 16.572266 C 8.896484 15.888672 8.75 15.15625 8.75 14.375 Z M 0 13.701172 C 0 13.375651 0.066732 13.064779 0.200195 12.768555 C 0.333659 12.472331 0.512695 12.211914 0.737305 11.987305 C 0.961914 11.762695 1.222331 11.583659 1.518555 11.450195 C 1.814779 11.316732 2.125651 11.25 2.451172 11.25 L 7.900391 11.25 C 7.809244 11.451823 7.722981 11.656901 7.641602 11.865234 C 7.560221 12.073568 7.490234 12.285156 7.431641 12.5 L 2.5 12.5 C 2.324219 12.5 2.161458 12.532553 2.011719 12.597656 C 1.861979 12.662761 1.730143 12.752279 1.616211 12.866211 C 1.502279 12.980144 1.41276 13.111979 1.347656 13.261719 C 1.282552 13.411459 1.25 13.574219 1.25 13.75 C 1.25 14.407553 1.359049 14.986979 1.577148 15.488281 C 1.795247 15.989584 2.091471 16.425781 2.46582 16.796875 C 2.840169 17.167969 3.273112 17.478842 3.764648 17.729492 C 4.256185 17.980143 4.777018 18.180338 5.327148 18.330078 C 5.877278 18.479818 6.438802 18.58724 7.011719 18.652344 C 7.584635 18.717447 8.138021 18.75 8.671875 18.75 C 8.847656 18.977865 9.033203 19.192709 9.228516 19.394531 C 9.423828 19.596354 9.635416 19.785156 9.863281 19.960938 C 9.674479 19.973959 9.488932 19.983725 9.306641 19.990234 C 9.124349 19.996744 8.938802 20 8.75 20 C 8.333333 20 7.908528 19.986979 7.475586 19.960938 C 7.042643 19.934896 6.612955 19.887695 6.186523 19.819336 C 5.760091 19.750977 5.340169 19.65983 4.926758 19.545898 C 4.513346 19.431967 4.114583 19.287109 3.730469 19.111328 C 3.157552 18.850912 2.641602 18.543295 2.182617 18.188477 C 1.723633 17.833658 1.333008 17.431641 1.010742 16.982422 C 0.688477 16.533203 0.439453 16.035156 0.263672 15.488281 C 0.087891 14.941406 0 14.345703 0 13.701172 Z M 14.375 15.253906 L 16.123047 17.001953 C 16.246744 17.12565 16.393229 17.1875 16.5625 17.1875 C 16.73177 17.1875 16.878254 17.12565 17.001953 17.001953 C 17.12565 16.878256 17.1875 16.731771 17.1875 16.5625 C 17.1875 16.39323 17.12565 16.246746 17.001953 16.123047 L 15.263672 14.375 L 17.001953 12.626953 C 17.12565 12.503256 17.1875 12.356771 17.1875 12.1875 C 17.1875 12.018229 17.12565 11.871745 17.001953 11.748047 C 16.878254 11.62435 16.73177 11.5625 16.5625 11.5625 C 16.393229 11.5625 16.246744 11.62435 16.123047 11.748047 L 14.375 13.486328 L 12.626953 11.748047 C 12.503255 11.62435 12.356771 11.5625 12.1875 11.5625 C 12.018229 11.5625 11.871744 11.62435 11.748047 11.748047 C 11.624349 11.871745 11.5625 12.018229 11.5625 12.1875 C 11.5625 12.356771 11.624349 12.503256 11.748047 12.626953 L 13.496094 14.375 L 11.748047 16.123047 C 11.624349 16.246746 11.5625 16.39323 11.5625 16.5625 C 11.5625 16.731771 11.624349 16.878256 11.748047 17.001953 C 11.871744 17.12565 12.018229 17.1875 12.1875 17.1875 C 12.356771 17.1875 12.503255 17.12565 12.626953 17.001953 Z " />
                             <TextBlock VerticalAlignment="Center" Text="{x:Bind domain:Translator.Unsubscribe}" />
                         </StackPanel>
                     </HyperlinkButton>
                 </Grid>
-                <CommandBar x:Name="RendererBar"
-                            Grid.Row="1"
-                            HorizontalContentAlignment="Stretch"
-                            DefaultLabelPosition="Right"
-                            DynamicOverflowItemsChanging="BarDynamicOverflowChanging"
-                            IsDynamicOverflowEnabled="True"
-                            OverflowButtonVisibility="Auto">
+                <CommandBar
+                    x:Name="RendererBar"
+                    Grid.Row="1"
+                    HorizontalContentAlignment="Stretch"
+                    DefaultLabelPosition="Right"
+                    DynamicOverflowItemsChanging="BarDynamicOverflowChanging"
+                    IsDynamicOverflowEnabled="True"
+                    OverflowButtonVisibility="Auto">
                     <interactivity:Interaction.Behaviors>
-                        <local:BindableCommandBarBehavior ItemClickedCommand="{x:Bind ViewModel.OperationClickedCommand}"
-                                                          ItemTemplateSelector="{StaticResource RendererCommandBarItemTemplateSelector}"
-                                                          PrimaryCommands="{x:Bind ViewModel.MenuItems, Mode=OneWay}" />
+                        <local:BindableCommandBarBehavior
+                            ItemClickedCommand="{x:Bind ViewModel.OperationClickedCommand}"
+                            ItemTemplateSelector="{StaticResource RendererCommandBarItemTemplateSelector}"
+                            PrimaryCommands="{x:Bind ViewModel.MenuItems, Mode=OneWay}" />
                     </interactivity:Interaction.Behaviors>
                     <CommandBar.Content>
                         <Grid Padding="0,5">
@@ -204,21 +223,24 @@
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
-                            <controls1:ImagePreviewControl x:Name="ContactImage"
-                                                           Width="36"
-                                                           Height="36"
-                                                           FontSize="16"
-                                                           FromAddress="{x:Bind ViewModel.FromAddress, Mode=OneWay}"
-                                                           FromName="{x:Bind ViewModel.FromName, Mode=OneWay}" />
+                            <controls1:ImagePreviewControl
+                                x:Name="ContactImage"
+                                Width="36"
+                                Height="36"
+                                FontSize="16"
+                                FromAddress="{x:Bind ViewModel.FromAddress, Mode=OneWay}"
+                                FromName="{x:Bind ViewModel.FromName, Mode=OneWay}" />
 
-                            <Grid Grid.Column="1"
-                                  Margin="12,0"
-                                  VerticalAlignment="Center">
+                            <Grid
+                                Grid.Column="1"
+                                Margin="12,0"
+                                VerticalAlignment="Center">
                                 <StackPanel Spacing="1">
-                                    <HyperlinkButton Padding="-2,0"
-                                                     Command="{Binding ElementName=root, Path=ViewModel.CopyClipboardCommand}"
-                                                     CommandParameter="{x:Bind ViewModel.FromAddress, Mode=OneWay}"
-                                                     FontWeight="SemiBold">
+                                    <HyperlinkButton
+                                        Padding="-2,0"
+                                        Command="{Binding ElementName=root, Path=ViewModel.CopyClipboardCommand}"
+                                        CommandParameter="{x:Bind ViewModel.FromAddress, Mode=OneWay}"
+                                        FontWeight="SemiBold">
                                         <TextBlock>
                                             <Run Text="{x:Bind ViewModel.FromName, Mode=OneWay}" />
                                             <Run Text="&lt;" /><Run Text="{x:Bind ViewModel.FromAddress, Mode=OneWay}" /><Run Text="&gt;" />
@@ -230,25 +252,29 @@
                         </Grid>
                     </CommandBar.Content>
                 </CommandBar>
-                <Grid Grid.Row="2"
-                      Margin="5,2,0,0"
-                      RowSpacing="4">
+                <Grid
+                    Grid.Row="2"
+                    Margin="5,2,0,0"
+                    RowSpacing="4">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <StackPanel x:Name="ToFromInformationPanel"
-                                Orientation="Vertical"
-                                Spacing="6">
+                    <StackPanel
+                        x:Name="ToFromInformationPanel"
+                        Orientation="Vertical"
+                        Spacing="6">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock VerticalAlignment="Center"
-                                       FontWeight="SemiBold"
-                                       Text="{x:Bind domain:Translator.ComposerTo}"
-                                       Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}" />
-                            <ItemsControl ItemTemplate="{StaticResource InternetAddressTemplate}"
-                                          ItemsSource="{x:Bind ViewModel.ToItems, Mode=OneWay}"
-                                          Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}">
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Text="{x:Bind domain:Translator.ComposerTo}"
+                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}" />
+                            <ItemsControl
+                                ItemTemplate="{StaticResource InternetAddressTemplate}"
+                                ItemsSource="{x:Bind ViewModel.ToItems, Mode=OneWay}"
+                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <ItemsStackPanel Orientation="Horizontal" />
@@ -258,13 +284,15 @@
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock VerticalAlignment="Center"
-                                       FontWeight="SemiBold"
-                                       Text="Cc:"
-                                       Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CCItemsItems.Count), Mode=OneWay}" />
-                            <ItemsControl ItemTemplate="{StaticResource InternetAddressTemplate}"
-                                          ItemsSource="{x:Bind ViewModel.CCItemsItems, Mode=OneWay}"
-                                          Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CCItemsItems.Count), Mode=OneWay}">
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Text="Cc:"
+                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CCItemsItems.Count), Mode=OneWay}" />
+                            <ItemsControl
+                                ItemTemplate="{StaticResource InternetAddressTemplate}"
+                                ItemsSource="{x:Bind ViewModel.CCItemsItems, Mode=OneWay}"
+                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CCItemsItems.Count), Mode=OneWay}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <ItemsStackPanel Orientation="Horizontal" />
@@ -274,13 +302,15 @@
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock VerticalAlignment="Center"
-                                       FontWeight="SemiBold"
-                                       Text="Bcc:"
-                                       Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BCCItems.Count), Mode=OneWay}" />
-                            <ItemsControl ItemTemplate="{StaticResource InternetAddressTemplate}"
-                                          ItemsSource="{x:Bind ViewModel.BCCItems, Mode=OneWay}"
-                                          Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BCCItems.Count), Mode=OneWay}">
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Text="Bcc:"
+                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BCCItems.Count), Mode=OneWay}" />
+                            <ItemsControl
+                                ItemTemplate="{StaticResource InternetAddressTemplate}"
+                                ItemsSource="{x:Bind ViewModel.BCCItems, Mode=OneWay}"
+                                Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BCCItems.Count), Mode=OneWay}">
                                 <ItemsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <ItemsStackPanel Orientation="Horizontal" />
@@ -297,15 +327,16 @@
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <ListView x:Name="AttachmentsListView"
-                              Grid.Row="3"
-                              Height="55"
-                              x:Load="{x:Bind helpers:XamlHelpers.CountToBooleanConverter(ViewModel.Attachments.Count), Mode=OneWay}"
-                              IsItemClickEnabled="True"
-                              ItemClick="AttachmentClicked"
-                              ItemTemplate="{StaticResource FileAttachmentTemplate}"
-                              ItemsSource="{x:Bind ViewModel.Attachments, Mode=OneWay}"
-                              SelectionMode="None">
+                    <ListView
+                        x:Name="AttachmentsListView"
+                        Grid.Row="3"
+                        Height="55"
+                        x:Load="{x:Bind helpers:XamlHelpers.CountToBooleanConverter(ViewModel.Attachments.Count), Mode=OneWay}"
+                        IsItemClickEnabled="True"
+                        ItemClick="AttachmentClicked"
+                        ItemTemplate="{StaticResource FileAttachmentTemplate}"
+                        ItemsSource="{x:Bind ViewModel.Attachments, Mode=OneWay}"
+                        SelectionMode="None">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <controls2:WrapPanel Orientation="Horizontal" />
@@ -313,57 +344,64 @@
                         </ItemsControl.ItemsPanel>
                     </ListView>
 
-                    <HyperlinkButton Content="{x:Bind domain:Translator.Reader_SaveAllAttachmentButtonText}"
-                                     Command="{x:Bind ViewModel.SaveAllAttachmentsCommand}"
-                                     Visibility="{x:Bind ViewModel.HasMultipleAttachments, Mode=OneWay}"
-                                     Grid.Column="1"
-                                     VerticalAlignment="Center" />
+                    <HyperlinkButton
+                        Content="{x:Bind domain:Translator.Reader_SaveAllAttachmentButtonText}"
+                        Command="{x:Bind ViewModel.SaveAllAttachmentsCommand}"
+                        Visibility="{x:Bind ViewModel.HasMultipleAttachments, Mode=OneWay}"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
                 </Grid>
 
 
-                <muxc:InfoBar x:Name="ImageLoadingDisabledMessage"
-                              Grid.Row="4"
-                              Margin="0,2"
-                              HorizontalContentAlignment="Stretch"
-                              x:Load="{x:Bind ViewModel.IsImageRenderingDisabled, Mode=OneWay}"
-                              IsOpen="True"
-                              Message="{x:Bind domain:Translator.ImageRenderingDisabled}"
-                              Severity="Warning">
+                <muxc:InfoBar
+                    x:Name="ImageLoadingDisabledMessage"
+                    Grid.Row="4"
+                    Margin="0,2"
+                    HorizontalContentAlignment="Stretch"
+                    x:Load="{x:Bind ViewModel.IsImageRenderingDisabled, Mode=OneWay}"
+                    IsOpen="True"
+                    Message="{x:Bind domain:Translator.ImageRenderingDisabled}"
+                    Severity="Warning">
                     <muxc:InfoBar.ActionButton>
-                        <Button HorizontalAlignment="Right"
-                                Command="{x:Bind ViewModel.ForceImageLoadingCommand}"
-                                Content="{x:Bind domain:Translator.Buttons_EnableImageRendering}" />
+                        <Button
+                            HorizontalAlignment="Right"
+                            Command="{x:Bind ViewModel.ForceImageLoadingCommand}"
+                            Content="{x:Bind domain:Translator.Buttons_EnableImageRendering}" />
                     </muxc:InfoBar.ActionButton>
                 </muxc:InfoBar>
 
-                <muxc:ProgressBar x:Name="DownloadingProgressBar"
-                                  Grid.Row="3"
-                                  Margin="12,1"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Top"
-                                  x:Load="{x:Bind ViewModel.ShouldDisplayDownloadProgress, Mode=OneWay}"
-                                  IsIndeterminate="{x:Bind ViewModel.IsIndetermineProgress, Mode=OneWay}"
-                                  Value="{x:Bind ViewModel.CurrentDownloadPercentage, Mode=OneWay}" />
+                <muxc:ProgressBar
+                    x:Name="DownloadingProgressBar"
+                    Grid.Row="3"
+                    Margin="12,1"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Top"
+                    x:Load="{x:Bind ViewModel.ShouldDisplayDownloadProgress, Mode=OneWay}"
+                    IsIndeterminate="{x:Bind ViewModel.IsIndetermineProgress, Mode=OneWay}"
+                    Value="{x:Bind ViewModel.CurrentDownloadPercentage, Mode=OneWay}" />
             </Grid>
         </Border>
 
-        <Border Grid.Row="1"
-                Background="{ThemeResource WinoContentZoneBackgroud}"
-                BorderBrush="{StaticResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="7">
+        <Border
+            Grid.Row="1"
+            Background="{ThemeResource WinoContentZoneBackgroud}"
+            BorderBrush="{StaticResource CardStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="7">
             <Grid Margin="1" CornerRadius="7">
                 <Grid Background="White" Visibility="{x:Bind IsDarkEditor, Converter={StaticResource ReverseBooleanToVisibilityConverter}, Mode=OneWay}" />
 
-                <controls:WebView2 x:Name="Chromium"
-                                   FontFamily="Segoe UI"
-                                   NavigationStarting="WebViewNavigationStarting" />
+                <controls:WebView2
+                    x:Name="Chromium"
+                    FontFamily="Segoe UI"
+                    NavigationStarting="WebViewNavigationStarting" />
 
-                <muxc:ProgressRing Width="50"
-                                   Height="50"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   IsActive="{x:Bind ViewModel.ShouldDisplayDownloadProgress, Mode=OneWay}" />
+                <muxc:ProgressRing
+                    Width="50"
+                    Height="50"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    IsActive="{x:Bind ViewModel.ShouldDisplayDownloadProgress, Mode=OneWay}" />
             </Grid>
         </Border>
         <VisualStateManager.VisualStateGroups>

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -31,7 +31,8 @@
 
         <DataTemplate x:Key="InternetAddressTemplate" x:DataType="entities:AccountContact">
             <HyperlinkButton
-                Padding="2"
+                Padding="4,2"
+                Margin="-2,-2"
                 Command="{Binding ElementName=root, Path=ViewModel.CopyClipboardCommand}"
                 CommandParameter="{x:Bind Address}"
                 Content="{x:Bind DisplayName}" />
@@ -228,6 +229,7 @@
                                 Width="36"
                                 Height="36"
                                 FontSize="16"
+                                SenderContactPicture="{x:Bind ViewModel.ContactPicture, Mode=OneWay}"
                                 FromAddress="{x:Bind ViewModel.FromAddress, Mode=OneWay}"
                                 FromName="{x:Bind ViewModel.FromName, Mode=OneWay}" />
 
@@ -237,7 +239,8 @@
                                 VerticalAlignment="Center">
                                 <StackPanel Spacing="1">
                                     <HyperlinkButton
-                                        Padding="-2,0"
+                                        Padding="4,2"
+                                        Margin="-6,-2"
                                         Command="{Binding ElementName=root, Path=ViewModel.CopyClipboardCommand}"
                                         CommandParameter="{x:Bind ViewModel.FromAddress, Mode=OneWay}"
                                         FontWeight="SemiBold">

--- a/Wino.Mail/Views/Settings/PersonalizationPage.xaml
+++ b/Wino.Mail/Views/Settings/PersonalizationPage.xaml
@@ -7,6 +7,7 @@
     xmlns:controls1="using:Wino.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:domain="using:Wino.Core.Domain"
+    x:Name="root"
     xmlns:enums="using:Wino.Core.Domain.Enums"
     xmlns:helpers="using:Wino.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -141,28 +142,22 @@
         <DataTemplate x:Key="CompactDisplayModePreviewTemplate" x:DataType="enums:MailListDisplayMode">
             <controls1:MailItemDisplayInformationControl
                 DisplayMode="Compact"
-                FromName="{x:Bind domain:Translator.SettingsPersonalizationMailDisplayCompactMode}"
-                ShowPreviewText="False"
-                Snippet="Thank you for using Wino Mail."
-                Subject="Welcome to Wino Mail" />
+                MailItem="{Binding ElementName=root, Path=ViewModel.DemoPreviewMailCopy}"
+                ShowPreviewText="False" />
         </DataTemplate>
 
         <DataTemplate x:Key="MediumDisplayModePreviewTemplate" x:DataType="enums:MailListDisplayMode">
             <controls1:MailItemDisplayInformationControl
                 DisplayMode="Medium"
-                FromName="{x:Bind domain:Translator.SettingsPersonalizationMailDisplayMediumMode}"
                 ShowPreviewText="True"
-                Snippet="Thank you for using Wino Mail."
-                Subject="Welcome to Wino Mail" />
+                MailItem="{Binding ElementName=root, Path=ViewModel.DemoPreviewMailCopy}" />
         </DataTemplate>
 
         <DataTemplate x:Key="SpaciousDisplayModePreviewTemplate" x:DataType="enums:MailListDisplayMode">
             <controls1:MailItemDisplayInformationControl
                 DisplayMode="Spacious"
-                FromName="{x:Bind domain:Translator.SettingsPersonalizationMailDisplaySpaciousMode}"
-                ShowPreviewText="True"
-                Snippet="Thank you for using Wino Mail."
-                Subject="Welcome to Wino Mail" />
+                MailItem="{Binding ElementName=root, Path=ViewModel.DemoPreviewMailCopy}"
+                ShowPreviewText="True" />
         </DataTemplate>
 
         <selectors:MailItemDisplayModePreviewTemplateSelector


### PR DESCRIPTION
This PR brings profile information picture data for Outlook and Gmail for the logged in account in use. Also fixes the regression bug that stopped toast notification actions to work.

Wino Mail does not have it's contact management system yet. However, that is also planned like Wino Calendar. Users still can not update contact info that Wino stores, but for logged in accounts this information is synchronized automatically in the background. Not all contacts, only logged in user data is fetched from the APIs. Later implementation with Wino People will have all contact synchronization.

Here's how it looks if I send from my Gmail account to Outlook account which has different picture:
![image](https://github.com/user-attachments/assets/58d9ed6d-96e7-4503-909c-e378d61e1b61)


**Changes**

- AddressInformation table renamed as AccountContact.
- Avatars for mails that have picture data is displayed where possible.
- Adding addresses for; to, cc and bcc fields will now show avatars. Picture avatar if possible, initials avatar if not.
- Fixed: Notification actions don't work.
- Fixed: Composer editor does not get the focus when the control itself is focused. It was kind of annoying.