### PR TITLE
Fixing Gmail SENT label deletes.

### DIFF
--- a/Wino.Core/Integration/Processors/DefaultChangeProcessor.cs
+++ b/Wino.Core/Integration/Processors/DefaultChangeProcessor.cs
@@ -21,7 +21,6 @@ namespace Wino.Core.Integration.Processors
     {
         Task UpdateAccountAsync(MailAccount account);
         Task<string> UpdateAccountDeltaSynchronizationIdentifierAsync(Guid accountId, string deltaSynchronizationIdentifier);
-        Task CreateAssignmentAsync(Guid accountId, string mailCopyId, string remoteFolderId);
         Task DeleteAssignmentAsync(Guid accountId, string mailCopyId, string remoteFolderId);
         Task ChangeMailReadStatusAsync(string mailCopyId, bool isRead);
         Task ChangeFlagStatusAsync(string mailCopyId, bool isFlagged);
@@ -53,6 +52,7 @@ namespace Wino.Core.Integration.Processors
     public interface IGmailChangeProcessor : IDefaultChangeProcessor
     {
         Task MapLocalDraftAsync(string mailCopyId, string newDraftId, string newThreadId);
+        Task CreateAssignmentAsync(Guid accountId, string mailCopyId, string remoteFolderId);
     }
 
     public interface IOutlookChangeProcessor : IDefaultChangeProcessor
@@ -135,8 +135,7 @@ namespace Wino.Core.Integration.Processors
         public Task DeleteAssignmentAsync(Guid accountId, string mailCopyId, string remoteFolderId)
             => MailService.DeleteAssignmentAsync(accountId, mailCopyId, remoteFolderId);
 
-        public Task CreateAssignmentAsync(Guid accountId, string mailCopyId, string remoteFolderId)
-            => MailService.CreateAssignmentAsync(accountId, mailCopyId, remoteFolderId);
+
 
         public Task DeleteMailAsync(Guid accountId, string mailId)
             => MailService.DeleteMailAsync(accountId, mailId);

--- a/Wino.Core/Integration/Processors/GmailChangeProcessor.cs
+++ b/Wino.Core/Integration/Processors/GmailChangeProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Services;
 
@@ -12,5 +13,8 @@ namespace Wino.Core.Integration.Processors
 
         public Task MapLocalDraftAsync(string mailCopyId, string newDraftId, string newThreadId)
             => MailService.MapLocalDraftAsync(mailCopyId, newDraftId, newThreadId);
+
+        public Task CreateAssignmentAsync(Guid accountId, string mailCopyId, string remoteFolderId)
+            => MailService.CreateAssignmentAsync(accountId, mailCopyId, remoteFolderId);
     }
 }

--- a/Wino.Core/Services/MailService.cs
+++ b/Wino.Core/Services/MailService.cs
@@ -409,12 +409,11 @@ namespace Wino.Core.Services
 
             foreach (var mailItem in allMails)
             {
-                await DeleteMailInternalAsync(mailItem).ConfigureAwait(false);
-
-                // Delete mime file.
+                // Delete mime file as well.
                 // Even though Gmail might have multiple copies for the same mail, we only have one MIME file for all.
                 // Their FileId is inserted same.
-                await _mimeFileService.DeleteMimeMessageAsync(accountId, mailItem.FileId);
+
+                await DeleteMailInternalAsync(mailItem, preserveMimeFile: false).ConfigureAwait(false);
             }
         }
 
@@ -457,7 +456,7 @@ namespace Wino.Core.Services
             ReportUIChange(new MailUpdatedMessage(mailCopy));
         }
 
-        private async Task DeleteMailInternalAsync(MailCopy mailCopy)
+        private async Task DeleteMailInternalAsync(MailCopy mailCopy, bool preserveMimeFile)
         {
             if (mailCopy == null)
             {
@@ -473,7 +472,7 @@ namespace Wino.Core.Services
             // If there are no more copies exists of the same mail, delete the MIME file as well.
             var isMailExists = await IsMailExistsAsync(mailCopy.Id).ConfigureAwait(false);
 
-            if (!isMailExists)
+            if (!isMailExists && !preserveMimeFile)
             {
                 await _mimeFileService.DeleteMimeMessageAsync(mailCopy.AssignedAccount.Id, mailCopy.FileId).ConfigureAwait(false);
             }
@@ -554,6 +553,19 @@ namespace Wino.Core.Services
                 return;
             }
 
+            if (mailCopy.AssignedFolder.SpecialFolderType == SpecialFolderType.Sent &&
+                localFolder.SpecialFolderType == SpecialFolderType.Deleted)
+            {
+                // Sent item is deleted.
+                // Gmail does not delete the sent items, but moves them to the deleted folder.
+                // API doesn't allow removing Sent label.
+                // Here we intercept this behavior, removing the Sent copy of the mail and adding the Deleted copy.
+                // This way item will only be visible in Trash folder as in Gmail Web UI.
+                // Don't delete MIME file since if exists.
+
+                await DeleteMailInternalAsync(mailCopy, preserveMimeFile: true).ConfigureAwait(false);
+            }
+
             // Copy one of the mail copy and assign it to the new folder.
             // We don't need to create a new MIME pack.
             // Therefore FileId is not changed for the new MailCopy.
@@ -585,7 +597,7 @@ namespace Wino.Core.Services
                 return;
             }
 
-            await DeleteMailInternalAsync(mailItem).ConfigureAwait(false);
+            await DeleteMailInternalAsync(mailItem, preserveMimeFile: false).ConfigureAwait(false);
         }
 
         public async Task<bool> CreateMailAsync(Guid accountId, NewMailItemPackage package)


### PR DESCRIPTION
Apparently Gmail API does not allow removing 'SENT' labels from the mails. It's only achieved through IMAP, therefore other clients don't have this problem.

When you delete an item from Sent folder in Gmail Web, 'TRASH' label is added and original SENT assignment is hidden from the UI. Either they have some sort of UI thing for these mails or they are removing the label internally. Not sure.

To mimic this behavior in Wino:

1- Requests that move items from Sent folder will not remove the SENT label, but add TRASH label.
2- Once the assignment change is dedected, Wino will remove SENT assignment copy from the original mail and add deleted folder assignment.

This way message will look like it's moved to Trash and will not be visible in Sent folder. Mime file and FileId are preserved during this change.