### PR TITLE
[Gmail] Synchorinizing alias names.

### DIFF
--- a/Wino.Core.Domain/Entities/MailAccountAlias.cs
+++ b/Wino.Core.Domain/Entities/MailAccountAlias.cs
@@ -33,6 +33,13 @@ namespace Wino.Core.Domain.Entities
         /// It can't be deleted or changed.
         /// </summary>
         public bool IsRootAlias { get; set; }
+
+        /// <summary>
+        /// Optional sender name for the alias.
+        /// Falls back to account's sender name if not set when preparing messages.
+        /// Used for Gmail only.
+        /// </summary>
+        public string AliasSenderName { get; set; }
     }
 
     public class MailAccountAlias : RemoteAccountAlias

--- a/Wino.Core/Extensions/GoogleIntegratorExtensions.cs
+++ b/Wino.Core/Extensions/GoogleIntegratorExtensions.cs
@@ -210,6 +210,7 @@ namespace Wino.Core.Extensions
                 IsRootAlias = a.IsDefault.GetValueOrDefault(),
                 IsPrimary = a.IsPrimary.GetValueOrDefault(),
                 ReplyToAddress = a.ReplyToAddress,
+                AliasSenderName = a.DisplayName,
                 IsVerified = a.VerificationStatus == "accepted" || a.IsDefault.GetValueOrDefault(),
             }).ToList();
         }

--- a/Wino.Core/Services/AccountService.cs
+++ b/Wino.Core/Services/AccountService.cs
@@ -412,7 +412,8 @@ namespace Wino.Core.Services
                         IsVerified = remoteAlias.IsVerified,
                         ReplyToAddress = remoteAlias.ReplyToAddress,
                         Id = Guid.NewGuid(),
-                        IsRootAlias = remoteAlias.IsRootAlias
+                        IsRootAlias = remoteAlias.IsRootAlias,
+                        AliasSenderName = remoteAlias.AliasSenderName
                     };
 
                     await Connection.InsertAsync(newAlias);
@@ -424,6 +425,7 @@ namespace Wino.Core.Services
                     existingAlias.IsPrimary = remoteAlias.IsPrimary;
                     existingAlias.IsVerified = remoteAlias.IsVerified;
                     existingAlias.ReplyToAddress = remoteAlias.ReplyToAddress;
+                    existingAlias.AliasSenderName = remoteAlias.AliasSenderName;
 
                     await Connection.UpdateAsync(existingAlias);
                 }

--- a/Wino.Mail.ViewModels/ComposePageViewModel.cs
+++ b/Wino.Mail.ViewModels/ComposePageViewModel.cs
@@ -449,7 +449,11 @@ namespace Wino.Mail.ViewModels
             if (SelectedAlias == null) return;
 
             CurrentMimeMessage.From.Clear();
-            CurrentMimeMessage.From.Add(new MailboxAddress(ComposingAccount.SenderName, SelectedAlias.AliasAddress));
+
+            // Try to get the sender name from the alias. If not, fallback to account sender name.
+            var senderName = SelectedAlias.AliasSenderName ?? ComposingAccount.SenderName;
+
+            CurrentMimeMessage.From.Add(new MailboxAddress(senderName, SelectedAlias.AliasAddress));
         }
 
         private void SaveReplyToAddress()


### PR DESCRIPTION
By default, all composed mails are sent from the sender name of the account. For Gmail though, aliases can have custom names like sales, billing etc. Users may want to utilize these names instead of the account they used to send mails.

This PR brings alias name sync support for Gmail only. Outlook sends the message directly from the alias's name and can't be customized. For IMAP, we can have additional dialog for later to modify alias names.