### PR TITLE
Added flyout on click for recipients

### DIFF
--- a/Wino.Core.Domain/Entities/AccountContact.cs
+++ b/Wino.Core.Domain/Entities/AccountContact.cs
@@ -36,6 +36,12 @@ namespace Wino.Core.Domain.Entities
         /// </summary>
         public bool IsRootContact { get; set; }
 
+        /// <summary>
+        /// Short display name of the contact.
+        /// Eather Name or Address.
+        /// </summary>
+        public string ShortDisplayName => Address == Name || string.IsNullOrWhiteSpace(Name) ? $"{Address.ToLowerInvariant()};" : $"{Name};";
+
         public string DisplayName => Address == Name || string.IsNullOrWhiteSpace(Name) ? Address.ToLowerInvariant() : $"{Name} <{Address.ToLowerInvariant()}>";
 
         public override bool Equals(object obj)
@@ -45,7 +51,7 @@ namespace Wino.Core.Domain.Entities
 
         public bool Equals(AccountContact other)
         {
-            return !(other is null) &&
+            return other is not null &&
                    Address == other.Address &&
                    Name == other.Name;
         }

--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -466,7 +466,15 @@ namespace Wino.Mail.ViewModels
                     var foundContact = await _contactService.GetAddressInformationByAddressAsync(mailboxAddress.Address).ConfigureAwait(false)
                         ?? new AccountContact() { Name = mailboxAddress.Name, Address = mailboxAddress.Address };
 
-                    accounts.Add(foundContact);
+                    // Make sure that user account first in the list.
+                    if (foundContact.Address == initializedMailItemViewModel.AssignedAccount.Address)
+                    {
+                        accounts.Insert(0, foundContact);
+                    }
+                    else
+                    {
+                        accounts.Add(foundContact);
+                    }
                 }
                 else if (item is GroupAddress groupAddress)
                 {

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -24,9 +24,42 @@
             <HyperlinkButton
                 Margin="-2,-2"
                 Padding="4,2"
-                Command="{Binding ElementName=root, Path=ViewModel.CopyClipboardCommand}"
-                CommandParameter="{x:Bind Address}"
-                Content="{x:Bind DisplayName}" />
+                Click="InternetAddressClicked"
+                Content="{x:Bind ShortDisplayName}"
+                ToolTipService.ToolTip="{x:Bind DisplayName}">
+                <HyperlinkButton.ContextFlyout>
+                    <Flyout Placement="Bottom">
+                        <Grid ColumnSpacing="10">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <controls:ImagePreviewControl
+                                Grid.RowSpan="2"
+                                Width="36"
+                                Height="36"
+                                FromAddress="{x:Bind Address}"
+                                FromName="{x:Bind Name}"
+                                SenderContactPicture="{x:Bind Base64ContactPicture}" />
+
+                            <TextBlock Grid.Column="1" Text="{x:Bind Name}" />
+
+                            <HyperlinkButton
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                Padding="0"
+                                Command="{Binding ElementName=root, Path=ViewModel.CopyClipboardCommand}"
+                                CommandParameter="{x:Bind Address}"
+                                Content="{x:Bind Address}" />
+                        </Grid>
+                    </Flyout>
+                </HyperlinkButton.ContextFlyout>
+            </HyperlinkButton>
         </DataTemplate>
 
         <!--  Attachment Template  -->
@@ -229,7 +262,7 @@
                     Grid.Row="2"
                     MaxHeight="150"
                     Margin="5,0">
-                    <Grid RowSpacing="4">
+                    <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
@@ -243,7 +276,7 @@
                             </Grid.ColumnDefinitions>
 
                             <TextBlock
-                                VerticalAlignment="Center"
+                                VerticalAlignment="Top"
                                 FontWeight="SemiBold"
                                 Text="{x:Bind domain:Translator.ComposerTo}"
                                 Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.ToItems.Count), Mode=OneWay}" />
@@ -266,7 +299,7 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
-                                VerticalAlignment="Center"
+                                VerticalAlignment="Top"
                                 FontWeight="SemiBold"
                                 Text="Cc:"
                                 Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CcItems.Count), Mode=OneWay}" />
@@ -289,7 +322,7 @@
                             </Grid.ColumnDefinitions>
 
                             <TextBlock
-                                VerticalAlignment="Center"
+                                VerticalAlignment="Top"
                                 FontWeight="SemiBold"
                                 Text="Bcc:"
                                 Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.BccItems.Count), Mode=OneWay}" />

--- a/Wino.Mail/Views/MailRenderingPage.xaml.cs
+++ b/Wino.Mail/Views/MailRenderingPage.xaml.cs
@@ -296,5 +296,13 @@ namespace Wino.Views
                 Crashes.TrackError(ex);
             }
         }
+
+        private void InternetAddressClicked(object sender, RoutedEventArgs e)
+        {
+            if (sender is HyperlinkButton hyperlinkButton)
+            {
+                hyperlinkButton.ContextFlyout.ShowAt(hyperlinkButton);
+            }
+        }
     }
 }


### PR DESCRIPTION
- User account will be first in recipients list
- Recipient shows either name or address to save space 
- Added tooltip which shows both ( Name and Address) 
- Added ";" to have visual separation between names, since we don't have address all the time. 
- To/Cc/Bcc now at the top of their container, previously they were centered and it was hard to understand is it To/CC/Bcc recipient when there many of them together.

Example of flyout: 
![image](https://github.com/user-attachments/assets/24a1627a-22ab-424f-9a6c-f896f3b50e8e)
