### PR TITLE
Fix for To/Cc/Bcc alignment and crush when opening eml 

### DIFF
--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -467,7 +467,7 @@ namespace Wino.Mail.ViewModels
                         ?? new AccountContact() { Name = mailboxAddress.Name, Address = mailboxAddress.Address };
 
                     // Make sure that user account first in the list.
-                    if (foundContact.Address == initializedMailItemViewModel.AssignedAccount.Address)
+                    if (foundContact.Address == initializedMailItemViewModel?.AssignedAccount?.Address)
                     {
                         accounts.Insert(0, foundContact);
                     }

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -276,6 +276,7 @@
                             </Grid.ColumnDefinitions>
 
                             <TextBlock
+                                Margin="0,1,0,0"
                                 VerticalAlignment="Top"
                                 FontWeight="SemiBold"
                                 Text="{x:Bind domain:Translator.ComposerTo}"
@@ -299,12 +300,14 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <TextBlock
+                                Margin="0,1,0,0"
                                 VerticalAlignment="Top"
                                 FontWeight="SemiBold"
                                 Text="Cc:"
                                 Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CcItems.Count), Mode=OneWay}" />
                             <ItemsControl
                                 Grid.Column="1"
+                                VerticalAlignment="Top"
                                 ItemTemplate="{StaticResource InternetAddressTemplate}"
                                 ItemsSource="{x:Bind ViewModel.CcItems, Mode=OneWay}"
                                 Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CcItems.Count), Mode=OneWay}">
@@ -322,6 +325,7 @@
                             </Grid.ColumnDefinitions>
 
                             <TextBlock
+                                Margin="0,1,0,0"
                                 VerticalAlignment="Top"
                                 FontWeight="SemiBold"
                                 Text="Bcc:"

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -307,7 +307,6 @@
                                 Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CcItems.Count), Mode=OneWay}" />
                             <ItemsControl
                                 Grid.Column="1"
-                                VerticalAlignment="Top"
                                 ItemTemplate="{StaticResource InternetAddressTemplate}"
                                 ItemsSource="{x:Bind ViewModel.CcItems, Mode=OneWay}"
                                 Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.CcItems.Count), Mode=OneWay}">


### PR DESCRIPTION
Fixed crash when opening eml
Fixes small misalignment after verticalAligement = top. 
Before: 
![image](https://github.com/user-attachments/assets/04c80941-4bb4-4d04-8595-60dea86d9270)

After: 
![image](https://github.com/user-attachments/assets/c9c13035-3426-48fb-858e-67f2758ef0ff)
