### PR TITLE
Fix mail header encoding issues with MimeKit

### DIFF
--- a/Wino.Server/App.xaml.cs
+++ b/Wino.Server/App.xaml.cs
@@ -150,6 +150,9 @@ namespace Wino.Server
 
             if (isCreatedNew)
             {
+                // Ensure proper encodings are available for MimeKit
+                System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+
                 // Spawn a thread which will be waiting for our event
                 var thread = new Thread(() =>
                 {

--- a/Wino.Server/Wino.Server.csproj
+++ b/Wino.Server/Wino.Server.csproj
@@ -33,6 +33,7 @@
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 	  <PackageReference Include="H.NotifyIcon.Wpf" Version="2.1.3" />
 	  <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="7.1.2" />
+	  <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Wino.Core.Domain\Wino.Core.Domain.csproj" />


### PR DESCRIPTION
Fixes #441, #317 

Following recommendations in MimeKit's [FAQ](https://github.com/jstedfast/MailKit/blob/master/FAQ.md#q-why-does-text-show-up-garbled-in-my-aspnet-core--net-core--net-5-app):
> .NET Core (and ASP.NET Core by extension) and .NET 5 only provide the Unicode encodings, ASCII and ISO-8859-1 by default. Other text encodings are not available to your application unless your application [registers](https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding.registerprovider?view=net-5.0) the encoding provider that provides all of the additional encodings.
> First, add a package reference for the [System.Text.Encoding.CodePages](https://www.nuget.org/packages/System.Text.Encoding.CodePages) nuget package to your project and then register the additional text encodings using the following code snippet:
> ```
> System.Text.Encoding.RegisterProvider (System.Text.CodePagesEncodingProvider.Instance);
> ```
> Note: The above code snippet should be safe to call in .NET Framework versions >= 4.6 as well.