### PR TITLE
Removed xaml converter for resolving mail subjects.

### DIFF
--- a/Wino.Core.UWP/Helpers/XamlHelpers.cs
+++ b/Wino.Core.UWP/Helpers/XamlHelpers.cs
@@ -71,7 +71,6 @@ namespace Wino.Helpers
                 return prefer24HourTime ? localTime.ToString(TwentyFourHourTimeFormat) : localTime.ToString(TwelveHourTimeFormat);
             }
         }
-        public static string GetMailItemSubject(string subject) => string.IsNullOrWhiteSpace(subject) ? $"({Translator.MailItemNoSubject})" : subject;
         public static string GetCreationDateString(DateTime date, bool prefer24HourTime)
         {
             var localTime = date.ToLocalTime();

--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -22,7 +22,6 @@ using Wino.Core.Domain.Models.MailItem;
 using Wino.Core.Domain.Models.Menus;
 using Wino.Core.Domain.Models.Navigation;
 using Wino.Core.Domain.Models.Reader;
-using Wino.Core.Services;
 using Wino.Mail.ViewModels.Data;
 using Wino.Mail.ViewModels.Messages;
 using Wino.Messaging.Client.Mails;
@@ -429,7 +428,7 @@ namespace Wino.Mail.ViewModels
                 foreach (var item in bccAccountContacts)
                     BccItems.Add(item);
 
-                Subject = message.Subject;
+                Subject = string.IsNullOrWhiteSpace(message.Subject) ? Translator.MailItemNoSubject : message.Subject;
 
                 // TODO: FromName and FromAddress is probably not correct here for mail lists.
                 FromAddress = message.From.Mailboxes.FirstOrDefault()?.Address ?? Translator.UnknownAddress;

--- a/Wino.Mail/Controls/MailItemDisplayInformationControl.xaml
+++ b/Wino.Mail/Controls/MailItemDisplayInformationControl.xaml
@@ -190,11 +190,11 @@
                                 <local:AnimatedIcon.RenderTransform />
                             </local:AnimatedIcon>
 
+                            <!--  Subject is bound in the code behind.  -->
                             <TextBlock
                                 x:Name="TitleText"
                                 Grid.Column="1"
                                 MaxLines="1"
-                                Text="{x:Bind helpers:XamlHelpers.GetMailItemSubject(MailItem.Subject)}"
                                 TextTrimming="CharacterEllipsis" />
 
                             <TextBlock

--- a/Wino.Mail/Controls/MailItemDisplayInformationControl.xaml.cs
+++ b/Wino.Mail/Controls/MailItemDisplayInformationControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Wino.Core.Domain;
 using Wino.Core.Domain.Entities.Mail;
 using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Models.MailItem;
@@ -27,7 +28,7 @@ namespace Wino.Controls
         public static readonly DependencyProperty CenterHoverActionProperty = DependencyProperty.Register(nameof(CenterHoverAction), typeof(MailOperation), typeof(MailItemDisplayInformationControl), new PropertyMetadata(MailOperation.None));
         public static readonly DependencyProperty RightHoverActionProperty = DependencyProperty.Register(nameof(RightHoverAction), typeof(MailOperation), typeof(MailItemDisplayInformationControl), new PropertyMetadata(MailOperation.None));
         public static readonly DependencyProperty HoverActionExecutedCommandProperty = DependencyProperty.Register(nameof(HoverActionExecutedCommand), typeof(ICommand), typeof(MailItemDisplayInformationControl), new PropertyMetadata(null));
-        public static readonly DependencyProperty MailItemProperty = DependencyProperty.Register(nameof(MailItem), typeof(IMailItem), typeof(MailItemDisplayInformationControl), new PropertyMetadata(null));
+        public static readonly DependencyProperty MailItemProperty = DependencyProperty.Register(nameof(MailItem), typeof(IMailItem), typeof(MailItemDisplayInformationControl), new PropertyMetadata(null, new PropertyChangedCallback(OnMailItemChanged)));
         public static readonly DependencyProperty IsHoverActionsEnabledProperty = DependencyProperty.Register(nameof(IsHoverActionsEnabled), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(true));
         public static readonly DependencyProperty Prefer24HourTimeFormatProperty = DependencyProperty.Register(nameof(Prefer24HourTimeFormat), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(false));
         public static readonly DependencyProperty IsThreadExpanderVisibleProperty = DependencyProperty.Register(nameof(IsThreadExpanderVisible), typeof(bool), typeof(MailItemDisplayInformationControl), new PropertyMetadata(false));
@@ -139,6 +140,21 @@ namespace Wino.Controls
             IconsContainer.EnableImplicitAnimation(VisualPropertyType.Offset, 400);
 
             RootContainerVisualWrapper.SizeChanged += (s, e) => leftBackgroundVisual.Size = e.NewSize.ToVector2();
+        }
+
+        private static void OnMailItemChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
+        {
+            if (obj is MailItemDisplayInformationControl control)
+            {
+                control.UpdateInformation();
+            }
+        }
+
+        private void UpdateInformation()
+        {
+            if (MailItem == null) return;
+
+            TitleText.Text = string.IsNullOrWhiteSpace(MailItem.Subject) ? Translator.MailItemNoSubject : MailItem.Subject;
         }
 
         private void ControlPointerEntered(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)

--- a/Wino.Mail/Views/MailRenderingPage.xaml
+++ b/Wino.Mail/Views/MailRenderingPage.xaml
@@ -181,7 +181,7 @@
                         FontSize="18"
                         FontWeight="SemiBold"
                         IsTextSelectionEnabled="True"
-                        Text="{x:Bind helpers:XamlHelpers.GetMailItemSubject( ViewModel.Subject), Mode=OneWay}"
+                        Text="{x:Bind ViewModel.Subject, Mode=OneWay}"
                         TextWrapping="Wrap" />
 
                     <HyperlinkButton


### PR DESCRIPTION
Looks like our XAML helper for converting empty subjects to no-subject translation does not trigger when the existing binding goes from any value to null. This caused couple subject bindings to mix with previously bind values.

This PR removes the usage of the converter and handles each binding separately in appropriate places.

Fixes #496 