### PR TITLE
Fix crash on launch when IMAP accounts are present

### DIFF
--- a/Wino.Core.UWP/Controls/ControlConstants.cs
+++ b/Wino.Core.UWP/Controls/ControlConstants.cs
@@ -71,6 +71,7 @@ namespace Wino.Core.UWP.Controls
             { WinoIconGlyph.Message, "\uE8BD" },
             { WinoIconGlyph.New, "\U000F002A" },
             { WinoIconGlyph.Blocked,"\uF140" },
+            { WinoIconGlyph.IMAP, "\uE715" },
             { WinoIconGlyph.Calendar, "\uE912" },
             { WinoIconGlyph.CalendarToday, "\uE911" },
             { WinoIconGlyph.CalendarDay, "\uE913" },


### PR DESCRIPTION
Getting crashes on launch:
```
2025-01-07 22:34:13.973 +02:00 [INF] [Wino Launch] OnWindowCreated -> IsWindowNull: False
2025-01-07 22:34:13.975 +02:00 [INF] OnActivated -> ProtocolActivatedEventArgs, Kind -> Protocol, Prev Execution State -> NotRunning
2025-01-07 22:34:14.011 +02:00 [INF] [Wino Launch] Window activated
2025-01-07 22:34:14.886 +02:00 [ERR] [Wino Crash]
System.Exception: Exception from HRESULT: 0x80131577
```
```csharp
        private void UpdateGlyph()
        {
            Glyph = ControlConstants.WinoIconFontDictionary[Icon];
        }
```
```
System.Collections.Generic.KeyNotFoundException
  HResult=0x80131577
  Message=The given key 'IMAP' was not present in the dictionary.
  Source=System.Private.CoreLib
  StackTrace:
   at System.ThrowHelper.ThrowKeyNotFoundException[T](T key)
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Wino.Core.UWP.Controls.WinoFontIcon.UpdateGlyph() in C:\Users\User\source\repos\Wino-Mail\Wino.Core.UWP\Controls\WinoFontIcon.cs:line 122
   at Wino.Core.UWP.Controls.WinoFontIcon.OnIconChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args) in C:\Users\User\source\repos\Wino-Mail\Wino.Core.UWP\Controls\WinoFontIcon.cs:line 116
```