### PR TITLE
Prevent Gmail Workspace account creation that has disabled Gmail service.

### DIFF
--- a/Wino.Core.Domain/Exceptions/GmailServiceDisabledException.cs
+++ b/Wino.Core.Domain/Exceptions/GmailServiceDisabledException.cs
@@ -1,0 +1,3 @@
+﻿namespace Wino.Core.Domain.Exceptions;
+
+public class GmailServiceDisabledException : System.Exception { }

--- a/Wino.Core.Domain/Translations/en_US/resources.json
+++ b/Wino.Core.Domain/Translations/en_US/resources.json
@@ -214,6 +214,8 @@
     "GeneralTitle_Error": "Error",
     "GeneralTitle_Info": "Information",
     "GeneralTitle_Warning": "Warning",
+    "GmailServiceDisabled_Title": "Gmail Error",
+    "GmailServiceDisabled_Message": "Your Google Workspace account seems to be disabled for Gmail service. Please contact your administrator to enable Gmail service for your account.",
     "HoverActionOption_Archive": "Archive",
     "HoverActionOption_Delete": "Delete",
     "HoverActionOption_MoveJunk": "Move to Junk",

--- a/Wino.Core/Synchronizers/GmailSynchronizer.cs
+++ b/Wino.Core/Synchronizers/GmailSynchronizer.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
+using Google;
 using Google.Apis.Calendar.v3.Data;
 using Google.Apis.Gmail.v1;
 using Google.Apis.Gmail.v1.Data;
@@ -120,7 +121,18 @@ public class GmailSynchronizer : WinoSynchronizer<IClientServiceRequest, Message
         {
             _logger.Information("Synchronizing folders for {Name}", Account.Name);
 
-            await SynchronizeFoldersAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await SynchronizeFoldersAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (GoogleApiException googleException) when (googleException.Message.Contains("Mail service not enabled"))
+            {
+                throw new GmailServiceDisabledException();
+            }
+            catch (Exception)
+            {
+                throw;
+            }
 
             _logger.Information("Synchronizing folders for {Name} is completed", Account.Name);
         }

--- a/Wino.Mail.ViewModels/AccountManagementViewModel.cs
+++ b/Wino.Mail.ViewModels/AccountManagementViewModel.cs
@@ -274,6 +274,19 @@ public partial class AccountManagementViewModel : AccountManagementPageViewModel
                 DialogService.InfoBarMessage(Translator.Info_AccountCreatedTitle, string.Format(Translator.Info_AccountCreatedMessage, createdAccount.Address), InfoBarMessageType.Success);
             }
         }
+        catch (GmailServiceDisabledException)
+        {
+            // For Google Workspace accounts, Gmail API might be disabled by the admin.
+            // Wino can't continue synchronization in this case.
+            // We must notify the user about this and prevent account creation.
+
+            DialogService.InfoBarMessage(Translator.GmailServiceDisabled_Title, Translator.GmailServiceDisabled_Message, InfoBarMessageType.Error);
+
+            if (createdAccount != null)
+            {
+                await AccountService.DeleteAccountAsync(createdAccount);
+            }
+        }
         catch (AccountSetupCanceledException)
         {
             // Ignore


### PR DESCRIPTION
Some Google Workspace accounts have their Gmail Service disabled by their admin. This was creating issues during the account setup because account was created successfully but then later nothing is synchronized.

