### PR TITLE
Handling of Gmail HistoryId Expiration.

### DIFF
--- a/Wino.Core.Domain/Enums/AccountCacheResetReason.cs
+++ b/Wino.Core.Domain/Enums/AccountCacheResetReason.cs
@@ -1,0 +1,7 @@
+﻿namespace Wino.Core.Domain.Enums;
+
+public enum AccountCacheResetReason
+{
+    AccountRemoval,
+    ExpiredCache
+}

--- a/Wino.Core.Domain/Interfaces/IAccountService.cs
+++ b/Wino.Core.Domain/Interfaces/IAccountService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Wino.Core.Domain.Entities.Mail;
 using Wino.Core.Domain.Entities.Shared;
+using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Models.Accounts;
 
 namespace Wino.Core.Domain.Interfaces;
@@ -156,4 +157,11 @@ public interface IAccountService
     /// <returns>Primary alias for the account.</returns>
     Task<MailAccountAlias> GetPrimaryAccountAliasAsync(Guid accountId);
     Task<bool> IsAccountFocusedEnabledAsync(Guid accountId);
+
+    /// <summary>
+    /// Deletes mail cache in the database for the given account.
+    /// </summary>
+    /// <param name="accountId">Account id.</param>
+    /// <param name="AccountCacheResetReason">Reason for the cache reset.</param>
+    Task DeleteAccountMailCacheAsync(Guid accountId, AccountCacheResetReason accountCacheResetReason);
 }

--- a/Wino.Core.Domain/Interfaces/IMailService.cs
+++ b/Wino.Core.Domain/Interfaces/IMailService.cs
@@ -135,4 +135,10 @@ public interface IMailService
     /// <param name="package">Mail creation package.</param>
     /// <returns></returns>
     Task CreateMailRawAsync(MailAccount account, MailItemFolder mailItemFolder, NewMailItemPackage package);
+
+    /// <summary>
+    /// Checks whether the account has any draft mail locally.
+    /// </summary>
+    /// <param name="accountId">Account id.</param>
+    Task<bool> HasAccountAnyDraftAsync(Guid accountId);
 }

--- a/Wino.Core.Domain/Interfaces/IMimeFileService.cs
+++ b/Wino.Core.Domain/Interfaces/IMimeFileService.cs
@@ -66,4 +66,10 @@ public interface IMimeFileService
     /// <param name="mimeLocalPath">File path that physical MimeMessage is located.</param>
     /// <param name="options">Rendering options</param>
     MailRenderModel GetMailRenderModel(MimeMessage message, string mimeLocalPath, MailRenderingOptions options = null);
+
+    /// <summary>
+    /// Deletes every file in the mime cache for the given account.
+    /// </summary>
+    /// <param name="accountId">Account id.</param>
+    Task DeleteUserMimeCacheAsync(Guid accountId);
 }

--- a/Wino.Core.Domain/Translations/en_US/resources.json
+++ b/Wino.Core.Domain/Translations/en_US/resources.json
@@ -4,6 +4,8 @@
     "AccountAlias_Column_Verified": "Verified",
     "AccountAlias_Disclaimer_FirstLine": "Wino can only import aliases for your Gmail accounts.",
     "AccountAlias_Disclaimer_SecondLine": "If you want to use aliases for your Outlook or IMAP account, please add them yourself.",
+    "AccountCacheReset_Title": "Account Cache Reset",
+    "AccountCacheReset_Message": "This account requires full re-sychronization to continue working. Please wait while Wino re-synchronizes your messages...",
     "AccountContactNameYou": "You",
     "AccountCreationDialog_Completed": "all done",
     "AccountCreationDialog_FetchingEvents": "Fetching calendar events.",

--- a/Wino.Core.UWP/Services/WinoServerConnectionManager.cs
+++ b/Wino.Core.UWP/Services/WinoServerConnectionManager.cs
@@ -258,7 +258,10 @@ public class WinoServerConnectionManager :
                 WeakReferenceMessenger.Default.Send(JsonSerializer.Deserialize(messageJson, CommunicationMessagesContext.Default.CopyAuthURLRequested));
                 break;
             case nameof(NewMailSynchronizationRequested):
-                WeakReferenceMessenger.Default.Send(JsonSerializer.Deserialize<NewMailSynchronizationRequested>(messageJson));
+                WeakReferenceMessenger.Default.Send(JsonSerializer.Deserialize(messageJson, CommunicationMessagesContext.Default.NewMailSynchronizationRequested));
+                break;
+            case nameof(AccountCacheResetMessage):
+                WeakReferenceMessenger.Default.Send(JsonSerializer.Deserialize(messageJson, CommunicationMessagesContext.Default.AccountCacheResetMessage));
                 break;
             default:
                 throw new Exception("Invalid data type name passed to client.");

--- a/Wino.Core/Integration/Processors/GmailChangeProcessor.cs
+++ b/Wino.Core/Integration/Processors/GmailChangeProcessor.cs
@@ -308,4 +308,6 @@ public class GmailChangeProcessor : DefaultChangeProcessor, IGmailChangeProcesso
         };
     }
 
+    public Task<bool> HasAccountAnyDraftAsync(Guid accountId)
+        => MailService.HasAccountAnyDraftAsync(accountId);
 }

--- a/Wino.Messages/CommunicationMessagesContext.cs
+++ b/Wino.Messages/CommunicationMessagesContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using Wino.Messaging.Server;
 using Wino.Messaging.UI;
 
 namespace Wino.Messaging;
@@ -23,4 +24,6 @@ namespace Wino.Messaging;
 [JsonSerializable(typeof(AccountSynchronizationProgressUpdatedMessage))]
 [JsonSerializable(typeof(AccountFolderConfigurationUpdated))]
 [JsonSerializable(typeof(CopyAuthURLRequested))]
+[JsonSerializable(typeof(NewMailSynchronizationRequested))]
+[JsonSerializable(typeof(AccountCacheResetMessage))]
 public partial class CommunicationMessagesContext : JsonSerializerContext;

--- a/Wino.Messages/UI/AccountCacheResetMessage.cs
+++ b/Wino.Messages/UI/AccountCacheResetMessage.cs
@@ -1,0 +1,7 @@
+﻿using System;
+using Wino.Core.Domain.Enums;
+
+namespace Wino.Messaging.UI;
+
+// Raised when the account's mail cache is reset.
+public record AccountCacheResetMessage(Guid AccountId, AccountCacheResetReason Reason) : UIMessageBase<AccountCacheResetMessage>;

--- a/Wino.Server/ServerContext.cs
+++ b/Wino.Server/ServerContext.cs
@@ -44,7 +44,8 @@ public class ServerContext :
     IRecipient<AccountFolderConfigurationUpdated>,
     IRecipient<CopyAuthURLRequested>,
     IRecipient<NewMailSynchronizationRequested>,
-    IRecipient<OnlineSearchRequested>
+    IRecipient<OnlineSearchRequested>,
+    IRecipient<AccountCacheResetMessage>
 {
     private readonly System.Timers.Timer _timer;
     private static object connectionLock = new object();
@@ -146,6 +147,8 @@ public class ServerContext :
     public async void Receive(NewMailSynchronizationRequested message) => await SendMessageAsync(MessageType.UIMessage, message);
 
     public async void Receive(OnlineSearchRequested message) => await SendMessageAsync(MessageType.UIMessage, message);
+
+    public async void Receive(AccountCacheResetMessage message) => await SendMessageAsync(MessageType.UIMessage, message);
 
     #endregion
 

--- a/Wino.Services/MailService.cs
+++ b/Wino.Services/MailService.cs
@@ -119,6 +119,18 @@ public class MailService : BaseDatabaseService, IMailService
         return mails;
     }
 
+    public async Task<bool> HasAccountAnyDraftAsync(Guid accountId)
+    {
+        // Get the draft folder.
+        var draftFolder = await _folderService.GetSpecialFolderByAccountIdAsync(accountId, SpecialFolderType.Draft);
+
+        if (draftFolder == null) return false;
+
+        var draftCount = await Connection.Table<MailCopy>().Where(a => a.FolderId == draftFolder.Id).CountAsync();
+
+        return draftCount > 0;
+    }
+
     public async Task<List<MailCopy>> GetUnreadMailsByFolderIdAsync(Guid folderId)
     {
         var unreadMails = await Connection.QueryAsync<MailCopy>("SELECT * FROM MailCopy WHERE FolderId = ? AND IsRead = 0", folderId);
@@ -143,7 +155,7 @@ public class MailService : BaseDatabaseService, IMailService
         //}
 
         // SQLite PCL doesn't support joins.
-        // We make the query using SqlKatka and execute it directly on SQLite-PCL.
+        // We make the query using SqlKata and execute it directly on SQLite-PCL.
 
         var query = new Query("MailCopy")
                     .Join("MailItemFolder", "MailCopy.FolderId", "MailItemFolder.Id")

--- a/Wino.Services/MimeFileService.cs
+++ b/Wino.Services/MimeFileService.cs
@@ -176,4 +176,22 @@ public class MimeFileService : IMimeFileService
 
         return renderingModel;
     }
+
+    public async Task DeleteUserMimeCacheAsync(Guid accountId)
+    {
+        var mimeFolderPath = await _nativeAppService.GetMimeMessageStoragePath().ConfigureAwait(false);
+        var mimeDirectory = Path.Combine(mimeFolderPath, accountId.ToString());
+
+        try
+        {
+            if (Directory.Exists(mimeDirectory))
+            {
+                Directory.Delete(mimeDirectory, true);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to remove user's mime cache folder.");
+        }
+    }
 }


### PR DESCRIPTION
When the client keeps an expired historyId as delta sync token for Gmail, users are left with re-adding the account as a solution. This PR brings few improvements around this area:

- Expired historyId will now reset the local cache and start full synchronization. (as [documented here](https://developers.google.com/gmail/api/guides/sync))
- Added removing the local cache methods.
- Fixed an issue with account deletion where the actual mails were still stored on the disk.
- Notifying users when the cache reset was needed for the account.
- Skipping draft mapping for Gmail if there are no local drafts.