### PR TITLE
build(Wino.Server.csproj): specify `RuntimeIdentifiers`

### DIFF
--- a/Wino.Server/Wino.Server.csproj
+++ b/Wino.Server/Wino.Server.csproj
@@ -9,6 +9,7 @@
     <CsWinRTComponent>true</CsWinRTComponent>
     <CsWinRTWindowsMetadata>10.0.22621.0</CsWinRTWindowsMetadata>
     <Platforms>x64;x86;ARM64</Platforms>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 	<IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
fixes an error that occurs when trying to build wino mail with msbuild from cli


![image](https://github.com/user-attachments/assets/34ae6e32-5f43-4001-9ff7-8891a34c2638)
