### PR TITLE
build(nuget.config): correct `nuget` packageSources key name

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -12,7 +12,7 @@
        everything else from nuget.org. -->
 	<packageSourceMapping>
 		<!-- key value for <packageSource> should match key values from <packageSources> element -->
-		<packageSource key="nuget.org">
+		<packageSource key="nuget">
 			<package pattern="*" />
 		</packageSource>
 		<packageSource key="labsFeed">


### PR DESCRIPTION
the key name doesn't contain ".org":

https://github.com/bkaankose/Wino-Mail/blob/c6048aea80e6550a9605ff1585ced841cdaf8e70/nuget.config#L6

fixes packages installation from cli 