### PR TITLE
Synchronizer error factory implementation

### DIFF
--- a/Wino.Core/CoreContainerSetup.cs
+++ b/Wino.Core/CoreContainerSetup.cs
@@ -4,6 +4,7 @@ using Wino.Authentication;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Integration.Processors;
 using Wino.Core.Services;
+using Wino.Core.Synchronizers.Errors.Outlook;
 using Wino.Core.Synchronizers.ImapSync;
 
 namespace Wino.Core;
@@ -34,6 +35,9 @@ public static class CoreContainerSetup
         services.AddTransient<CondstoreSynchronizer>();
         services.AddTransient<QResyncSynchronizer>();
         services.AddTransient<UidBasedSynchronizer>();
+
+        // Register error factory handlers
+        services.AddTransient<ObjectCannotBeDeletedHandler>();
 
         services.AddTransient<IOutlookSynchronizerErrorHandlerFactory, OutlookSynchronizerErrorHandlingFactory>();
         services.AddTransient<IGmailSynchronizerErrorHandlerFactory, GmailSynchronizerErrorHandlingFactory>();

--- a/Wino.Core/CoreContainerSetup.cs
+++ b/Wino.Core/CoreContainerSetup.cs
@@ -34,5 +34,8 @@ public static class CoreContainerSetup
         services.AddTransient<CondstoreSynchronizer>();
         services.AddTransient<QResyncSynchronizer>();
         services.AddTransient<UidBasedSynchronizer>();
+
+        services.AddTransient<IOutlookSynchronizerErrorHandlerFactory, OutlookSynchronizerErrorHandlingFactory>();
+        services.AddTransient<IGmailSynchronizerErrorHandlerFactory, GmailSynchronizerErrorHandlingFactory>();
     }
 }

--- a/Wino.Core/Domain/Interfaces/ISynchronizerErrorHandler.cs
+++ b/Wino.Core/Domain/Interfaces/ISynchronizerErrorHandler.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using Wino.Core.Domain.Models.Errors;
+
+namespace Wino.Core.Domain.Interfaces;
+
+/// <summary>
+/// Interface for handling specific synchronizer errors
+/// </summary>
+public interface ISynchronizerErrorHandler
+{
+    /// <summary>
+    /// Determines if this handler can handle the specified error
+    /// </summary>
+    /// <param name="error">The error to check</param>
+    /// <returns>True if this handler can handle the error, false otherwise</returns>
+    bool CanHandle(SynchronizerErrorContext error);
+
+    /// <summary>
+    /// Handles the specified error
+    /// </summary>
+    /// <param name="error">The error to handle</param>
+    /// <returns>A task that completes when the error is handled</returns>
+    Task HandleAsync(SynchronizerErrorContext error);
+}
+
+public interface ISynchronizerErrorHandlerFactory
+{
+    Task<bool> HandleErrorAsync(SynchronizerErrorContext error);
+}
+
+public interface IOutlookSynchronizerErrorHandlerFactory : ISynchronizerErrorHandlerFactory;
+public interface IGmailSynchronizerErrorHandlerFactory : ISynchronizerErrorHandlerFactory;

--- a/Wino.Core/Domain/Interfaces/ISynchronizerErrorHandler.cs
+++ b/Wino.Core/Domain/Interfaces/ISynchronizerErrorHandler.cs
@@ -20,7 +20,7 @@ public interface ISynchronizerErrorHandler
     /// </summary>
     /// <param name="error">The error to handle</param>
     /// <returns>A task that completes when the error is handled</returns>
-    Task HandleAsync(SynchronizerErrorContext error);
+    Task<bool> HandleAsync(SynchronizerErrorContext error);
 }
 
 public interface ISynchronizerErrorHandlerFactory

--- a/Wino.Core/Domain/Models/Errors/SynchronizerErrorContext.cs
+++ b/Wino.Core/Domain/Models/Errors/SynchronizerErrorContext.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using Wino.Core.Domain.Interfaces;
+
+namespace Wino.Core.Domain.Models.Errors;
+
+/// <summary>
+/// Contains context information about a synchronizer error
+/// </summary>
+public class SynchronizerErrorContext
+{
+    /// <summary>
+    /// Gets or sets the error code
+    /// </summary>
+    public int? ErrorCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the error message
+    /// </summary>
+    public string ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets the request bundle associated with the error
+    /// </summary>
+    public IRequestBundle RequestBundle { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional data associated with the error
+    /// </summary>
+    public Dictionary<string, object> AdditionalData { get; set; } = new Dictionary<string, object>();
+
+    /// <summary>
+    /// Gets or sets the exception associated with the error
+    /// </summary>
+    public Exception Exception { get; set; }
+}

--- a/Wino.Core/Domain/Models/Errors/SynchronizerErrorContext.cs
+++ b/Wino.Core/Domain/Models/Errors/SynchronizerErrorContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Wino.Core.Domain.Entities.Shared;
 using Wino.Core.Domain.Interfaces;
 
 namespace Wino.Core.Domain.Models.Errors;
@@ -9,6 +10,11 @@ namespace Wino.Core.Domain.Models.Errors;
 /// </summary>
 public class SynchronizerErrorContext
 {
+    /// <summary>
+    /// Account associated with the error
+    /// </summary>
+    public MailAccount Account { get; set; }
+
     /// <summary>
     /// Gets or sets the error code
     /// </summary>

--- a/Wino.Core/Services/GmailSynchronizerErrorHandlingFactory.cs
+++ b/Wino.Core/Services/GmailSynchronizerErrorHandlingFactory.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Wino.Core.Domain.Interfaces;
+using Wino.Core.Domain.Models.Errors;
+
+namespace Wino.Core.Services;
+public class GmailSynchronizerErrorHandlingFactory : SynchronizerErrorHandlingFactory, IGmailSynchronizerErrorHandlerFactory
+{
+    public bool CanHandle(SynchronizerErrorContext error) => CanHandle(error);
+
+    public Task HandleAsync(SynchronizerErrorContext error) => HandleErrorAsync(error);
+}

--- a/Wino.Core/Services/OutlookSynchronizerErrorHandlingFactory.cs
+++ b/Wino.Core/Services/OutlookSynchronizerErrorHandlingFactory.cs
@@ -7,9 +7,9 @@ namespace Wino.Core.Services;
 
 public class OutlookSynchronizerErrorHandlingFactory : SynchronizerErrorHandlingFactory, IOutlookSynchronizerErrorHandlerFactory
 {
-    public OutlookSynchronizerErrorHandlingFactory()
+    public OutlookSynchronizerErrorHandlingFactory(ObjectCannotBeDeletedHandler objectCannotBeDeleted)
     {
-        RegisterHandler(new ObjectCannotBeDeletedHandler());
+        RegisterHandler(objectCannotBeDeleted);
     }
 
     public bool CanHandle(SynchronizerErrorContext error) => CanHandle(error);

--- a/Wino.Core/Services/OutlookSynchronizerErrorHandlingFactory.cs
+++ b/Wino.Core/Services/OutlookSynchronizerErrorHandlingFactory.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Wino.Core.Domain.Interfaces;
+using Wino.Core.Domain.Models.Errors;
+using Wino.Core.Synchronizers.Errors.Outlook;
+
+namespace Wino.Core.Services;
+
+public class OutlookSynchronizerErrorHandlingFactory : SynchronizerErrorHandlingFactory, IOutlookSynchronizerErrorHandlerFactory
+{
+    public OutlookSynchronizerErrorHandlingFactory()
+    {
+        RegisterHandler(new ObjectCannotBeDeletedHandler());
+    }
+
+    public bool CanHandle(SynchronizerErrorContext error) => CanHandle(error);
+
+    public Task HandleAsync(SynchronizerErrorContext error) => HandleErrorAsync(error);
+}

--- a/Wino.Core/Services/SynchronizerErrorHandlingFactory.cs
+++ b/Wino.Core/Services/SynchronizerErrorHandlingFactory.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Serilog;
+using Wino.Core.Domain.Interfaces;
+using Wino.Core.Domain.Models.Errors;
+
+namespace Wino.Core.Services;
+
+/// <summary>
+/// Factory for handling synchronizer errors
+/// </summary>
+public class SynchronizerErrorHandlingFactory
+{
+    private readonly ILogger _logger = Log.ForContext<SynchronizerErrorHandlingFactory>();
+    private readonly List<ISynchronizerErrorHandler> _handlers = new();
+
+    /// <summary>
+    /// Registers an error handler
+    /// </summary>
+    /// <param name="handler">The handler to register</param>
+    public void RegisterHandler(ISynchronizerErrorHandler handler)
+    {
+        _handlers.Add(handler);
+    }
+
+    /// <summary>
+    /// Handles an error using the registered handlers
+    /// </summary>
+    /// <param name="error">The error to handle</param>
+    /// <returns>True if the error was handled, false otherwise</returns>
+    public async Task<bool> HandleErrorAsync(SynchronizerErrorContext error)
+    {
+        foreach (var handler in _handlers)
+        {
+            if (handler.CanHandle(error))
+            {
+                _logger.Debug("Found handler {HandlerType} for error code {ErrorCode} message {ErrorMessage}", 
+                    handler.GetType().Name, error.ErrorCode, error.ErrorMessage);
+                
+                await handler.HandleAsync(error);
+                return true;
+            }
+        }
+        
+        _logger.Debug("No handler found for error code {ErrorCode} message {ErrorMessage}", 
+            error.ErrorCode, error.ErrorMessage);
+        
+        return false;
+    }
+}

--- a/Wino.Core/Services/SynchronizerErrorHandlingFactory.cs
+++ b/Wino.Core/Services/SynchronizerErrorHandlingFactory.cs
@@ -34,17 +34,16 @@ public class SynchronizerErrorHandlingFactory
         {
             if (handler.CanHandle(error))
             {
-                _logger.Debug("Found handler {HandlerType} for error code {ErrorCode} message {ErrorMessage}", 
+                _logger.Debug("Found handler {HandlerType} for error code {ErrorCode} message {ErrorMessage}",
                     handler.GetType().Name, error.ErrorCode, error.ErrorMessage);
-                
-                await handler.HandleAsync(error);
-                return true;
+
+                return await handler.HandleAsync(error);
             }
         }
-        
-        _logger.Debug("No handler found for error code {ErrorCode} message {ErrorMessage}", 
+
+        _logger.Debug("No handler found for error code {ErrorCode} message {ErrorMessage}",
             error.ErrorCode, error.ErrorMessage);
-        
+
         return false;
     }
 }

--- a/Wino.Core/Services/SynchronizerFactory.cs
+++ b/Wino.Core/Services/SynchronizerFactory.cs
@@ -15,6 +15,8 @@ public class SynchronizerFactory : ISynchronizerFactory
     private readonly IAccountService _accountService;
     private readonly IImapSynchronizationStrategyProvider _imapSynchronizationStrategyProvider;
     private readonly IApplicationConfiguration _applicationConfiguration;
+    private readonly IOutlookSynchronizerErrorHandlerFactory _outlookSynchronizerErrorHandlerFactory;
+    private readonly IGmailSynchronizerErrorHandlerFactory _gmailSynchronizerErrorHandlerFactory;
     private readonly IOutlookChangeProcessor _outlookChangeProcessor;
     private readonly IGmailChangeProcessor _gmailChangeProcessor;
     private readonly IImapChangeProcessor _imapChangeProcessor;
@@ -30,7 +32,9 @@ public class SynchronizerFactory : ISynchronizerFactory
                                IGmailAuthenticator gmailAuthenticator,
                                IAccountService accountService,
                                IImapSynchronizationStrategyProvider imapSynchronizationStrategyProvider,
-                               IApplicationConfiguration applicationConfiguration)
+                               IApplicationConfiguration applicationConfiguration,
+                               IOutlookSynchronizerErrorHandlerFactory outlookSynchronizerErrorHandlerFactory,
+                               IGmailSynchronizerErrorHandlerFactory gmailSynchronizerErrorHandlerFactory)
     {
         _outlookChangeProcessor = outlookChangeProcessor;
         _gmailChangeProcessor = gmailChangeProcessor;
@@ -40,6 +44,8 @@ public class SynchronizerFactory : ISynchronizerFactory
         _accountService = accountService;
         _imapSynchronizationStrategyProvider = imapSynchronizationStrategyProvider;
         _applicationConfiguration = applicationConfiguration;
+        _outlookSynchronizerErrorHandlerFactory = outlookSynchronizerErrorHandlerFactory;
+        _gmailSynchronizerErrorHandlerFactory = gmailSynchronizerErrorHandlerFactory;
     }
 
     public async Task<IWinoSynchronizerBase> GetAccountSynchronizerAsync(Guid accountId)
@@ -69,9 +75,9 @@ public class SynchronizerFactory : ISynchronizerFactory
         switch (providerType)
         {
             case Domain.Enums.MailProviderType.Outlook:
-                return new OutlookSynchronizer(mailAccount, _outlookAuthenticator, _outlookChangeProcessor);
+                return new OutlookSynchronizer(mailAccount, _outlookAuthenticator, _outlookChangeProcessor, _outlookSynchronizerErrorHandlerFactory);
             case Domain.Enums.MailProviderType.Gmail:
-                return new GmailSynchronizer(mailAccount, _gmailAuthenticator, _gmailChangeProcessor);
+                return new GmailSynchronizer(mailAccount, _gmailAuthenticator, _gmailChangeProcessor, _gmailSynchronizerErrorHandlerFactory);
             case Domain.Enums.MailProviderType.IMAP4:
                 return new ImapSynchronizer(mailAccount, _imapChangeProcessor, _imapSynchronizationStrategyProvider, _applicationConfiguration);
             default:

--- a/Wino.Core/Synchronizers/Errors/Outlook/ObjectCannotBeDeletedHandler.cs
+++ b/Wino.Core/Synchronizers/Errors/Outlook/ObjectCannotBeDeletedHandler.cs
@@ -1,21 +1,39 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Microsoft.Kiota.Abstractions;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Models.Errors;
+using Wino.Core.Domain.Models.Requests;
+using Wino.Core.Requests.Bundles;
 
 namespace Wino.Core.Synchronizers.Errors.Outlook;
 
-internal class ObjectCannotBeDeletedHandler : ISynchronizerErrorHandler
+public class ObjectCannotBeDeletedHandler : ISynchronizerErrorHandler
 {
-    public bool CanHandle(SynchronizerErrorContext error)
+    private readonly IMailService _mailService;
+
+    public ObjectCannotBeDeletedHandler(IMailService mailService)
     {
-        return error.ErrorMessage.Contains("ObjectCannotBeDeleted");
+        _mailService = mailService;
     }
 
-    public Task HandleAsync(SynchronizerErrorContext error)
+    public bool CanHandle(SynchronizerErrorContext error)
     {
-        // Handle the error here, e.g., log it or notify the user
-        Console.WriteLine($"Error: {error.ErrorMessage}");
-        return Task.CompletedTask;
+        return error.ErrorMessage.Contains("ErrorCannotDeleteObject") && error.RequestBundle is HttpRequestBundle<RequestInformation>;
+    }
+
+    public async Task<bool> HandleAsync(SynchronizerErrorContext error)
+    {
+        var castedBundle = error.RequestBundle as HttpRequestBundle<RequestInformation>;
+
+        if (castedBundle?.Request is MailRequestBase mailRequest)
+        {
+            var request = castedBundle.Request;
+
+            await _mailService.DeleteMailAsync(error.Account.Id, mailRequest.Item.Id);
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Wino.Core/Synchronizers/Errors/Outlook/ObjectCannotBeDeletedHandler.cs
+++ b/Wino.Core/Synchronizers/Errors/Outlook/ObjectCannotBeDeletedHandler.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading.Tasks;
+using Wino.Core.Domain.Interfaces;
+using Wino.Core.Domain.Models.Errors;
+
+namespace Wino.Core.Synchronizers.Errors.Outlook;
+
+internal class ObjectCannotBeDeletedHandler : ISynchronizerErrorHandler
+{
+    public bool CanHandle(SynchronizerErrorContext error)
+    {
+        return error.ErrorMessage.Contains("ObjectCannotBeDeleted");
+    }
+
+    public Task HandleAsync(SynchronizerErrorContext error)
+    {
+        // Handle the error here, e.g., log it or notify the user
+        Console.WriteLine($"Error: {error.ErrorMessage}");
+        return Task.CompletedTask;
+    }
+}

--- a/Wino.Core/Synchronizers/OutlookSynchronizer.cs
+++ b/Wino.Core/Synchronizers/OutlookSynchronizer.cs
@@ -692,7 +692,7 @@ public class OutlookSynchronizer : WinoSynchronizer<RequestInformation, Message,
     {
         return ForEachRequest(request, (item) =>
         {
-            return _graphClient.Me.Messages[item.Item.Id].ToDeleteRequestInformation();
+            return _graphClient.Me.Messages["123123123"].ToDeleteRequestInformation();
         });
     }
 
@@ -1004,6 +1004,7 @@ public class OutlookSynchronizer : WinoSynchronizer<RequestInformation, Message,
         // Create error context
         var errorContext = new SynchronizerErrorContext
         {
+            Account = Account,
             ErrorCode = (int)response.StatusCode,
             ErrorMessage = errorMessage,
             RequestBundle = bundle,

--- a/Wino.Core/Synchronizers/OutlookSynchronizer.cs
+++ b/Wino.Core/Synchronizers/OutlookSynchronizer.cs
@@ -30,6 +30,7 @@ using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Exceptions;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Models.Accounts;
+using Wino.Core.Domain.Models.Errors;
 using Wino.Core.Domain.Models.Folders;
 using Wino.Core.Domain.Models.MailItem;
 using Wino.Core.Domain.Models.Synchronization;
@@ -83,9 +84,12 @@ public class OutlookSynchronizer : WinoSynchronizer<RequestInformation, Message,
     private readonly ILogger _logger = Log.ForContext<OutlookSynchronizer>();
     private readonly IOutlookChangeProcessor _outlookChangeProcessor;
     private readonly GraphServiceClient _graphClient;
+    private readonly IOutlookSynchronizerErrorHandlerFactory _errorHandlingFactory;
+
     public OutlookSynchronizer(MailAccount account,
                                IAuthenticator authenticator,
-                               IOutlookChangeProcessor outlookChangeProcessor) : base(account)
+                               IOutlookChangeProcessor outlookChangeProcessor,
+                               IOutlookSynchronizerErrorHandlerFactory errorHandlingFactory) : base(account)
     {
         var tokenProvider = new MicrosoftTokenProvider(Account, authenticator);
 
@@ -106,6 +110,7 @@ public class OutlookSynchronizer : WinoSynchronizer<RequestInformation, Message,
         _graphClient = new GraphServiceClient(httpClient, new BaseBearerTokenAuthenticationProvider(tokenProvider));
 
         _outlookChangeProcessor = outlookChangeProcessor;
+        _errorHandlingFactory = errorHandlingFactory;
     }
 
     #region MS Graph Handlers
@@ -990,14 +995,36 @@ public class OutlookSynchronizer : WinoSynchronizer<RequestInformation, Message,
         HttpResponseMessage response,
         List<string> errors)
     {
-        bundle.UIChangeRequest?.RevertUIChanges();
-
         var content = await response.Content.ReadAsStringAsync();
         var errorJson = JsonNode.Parse(content);
-        var errorString = $"[{response.StatusCode}] {errorJson["error"]["code"]} - {errorJson["error"]["message"]}\n";
+        var errorCode = errorJson["error"]["code"].GetValue<string>();
+        var errorMessage = errorJson["error"]["message"].GetValue<string>();
+        var errorString = $"[{response.StatusCode}] {errorCode} - {errorMessage}\n";
 
-        Debug.WriteLine(errorString);
-        errors.Add(errorString);
+        // Create error context
+        var errorContext = new SynchronizerErrorContext
+        {
+            ErrorCode = (int)response.StatusCode,
+            ErrorMessage = errorMessage,
+            RequestBundle = bundle,
+            AdditionalData = new Dictionary<string, object>
+            {
+                { "ErrorCode", errorCode },
+                { "HttpResponse", response },
+                { "Content", content }
+            }
+        };
+
+        // Try to handle the error with registered handlers
+        var handled = await _errorHandlingFactory.HandleErrorAsync(errorContext);
+
+        // If not handled by any specific handler, revert UI changes and add to error list
+        if (!handled)
+        {
+            bundle.UIChangeRequest?.RevertUIChanges();
+            Debug.WriteLine(errorString);
+            errors.Add(errorString);
+        }
     }
 
     private void ThrowBatchExecutionException(List<string> errors)

--- a/Wino.Core/Synchronizers/OutlookSynchronizer.cs
+++ b/Wino.Core/Synchronizers/OutlookSynchronizer.cs
@@ -692,7 +692,7 @@ public class OutlookSynchronizer : WinoSynchronizer<RequestInformation, Message,
     {
         return ForEachRequest(request, (item) =>
         {
-            return _graphClient.Me.Messages["123123123"].ToDeleteRequestInformation();
+            return _graphClient.Me.Messages[item.Item.Id].ToDeleteRequestInformation();
         });
     }
 

--- a/Wino.Mail/Views/MailListPage.xaml
+++ b/Wino.Mail/Views/MailListPage.xaml
@@ -203,6 +203,8 @@
             Key="A"
             Invoked="SelectAllInvoked"
             Modifiers="Control" />
+
+        <KeyboardAccelerator Key="Delete" Invoked="DeleteAllInvoked" />
     </Page.KeyboardAccelerators>
     <wino:BasePage.ShellContent>
         <Grid>

--- a/Wino.Mail/Views/MailListPage.xaml.cs
+++ b/Wino.Mail/Views/MailListPage.xaml.cs
@@ -495,4 +495,7 @@ public sealed partial class MailListPage : MailListPageAbstract,
 
     private void SelectAllInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         => MailListView.SelectAllWino();
+
+    private void DeleteAllInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        => ViewModel.ExecuteMailOperationCommand.Execute(MailOperation.SoftDelete);
 }

--- a/Wino.Server/MessageHandlers/UserActionRequestHandler.cs
+++ b/Wino.Server/MessageHandlers/UserActionRequestHandler.cs
@@ -24,17 +24,6 @@ public class UserActionRequestHandler : ServerMessageHandler<ServerRequestPackag
         var synchronizer = await _synchronizerFactory.GetAccountSynchronizerAsync(package.AccountId);
         synchronizer.QueueRequest(package.Request);
 
-        //if (package.QueueSynchronization)
-        //{
-        //    var options = new SynchronizationOptions
-        //    {
-        //        AccountId = package.AccountId,
-        //        Type = Wino.Core.Domain.Enums.SynchronizationType.ExecuteRequests
-        //    };
-
-        //    WeakReferenceMessenger.Default.Send(new NewSynchronizationRequested(options));
-        //}
-
         return WinoServerResponse<bool>.CreateSuccessResponse(true);
     }
 }


### PR DESCRIPTION
There are some errors raised by APIs that require special handling of requests. This implementation brings a new system to detect those changes and handle individually. Right now only ObjectCannotBeDeleted error for Outlook API is handled, but can be increased more as investigations of the errors increase.