### PR TITLE
Fix for disabled notifications.

### DIFF
--- a/Wino.Core.Domain/Interfaces/IAccountService.cs
+++ b/Wino.Core.Domain/Interfaces/IAccountService.cs
@@ -162,4 +162,12 @@ public interface IAccountService
     /// <param name="accountId">Identifies the account for which the synchronization identifier is being updated.</param>
     /// <param name="syncIdentifier">Represents the new synchronization identifier to be set for the specified account.</param>
     Task<string> UpdateSyncIdentifierRawAsync(Guid accountId, string syncIdentifier);
+
+
+    /// <summary>
+    /// Gets whether the notifications are enabled for the given account id.
+    /// </summary>
+    /// <param name="accountId">Account id.</param>
+    /// <returns>Whether the notifications should be created after sync or not.</returns>
+    Task<bool> IsNotificationsEnabled(Guid accountId);
 }

--- a/Wino.Services/AccountService.cs
+++ b/Wino.Services/AccountService.cs
@@ -615,4 +615,11 @@ public class AccountService : BaseDatabaseService, IAccountService
         var account = await GetAccountAsync(accountId);
         return account.Preferences.IsFocusedInboxEnabled.GetValueOrDefault();
     }
+
+    public async Task<bool> IsNotificationsEnabled(Guid accountId)
+    {
+        var account = await GetAccountAsync(accountId);
+
+        return account?.Preferences?.IsNotificationsEnabled ?? false;
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where notifications were still created after the sync is done since at the time of sync completion the account preference was still had the old value.

Fixes #632