### PR TITLE
Outlook Auth Fix

### DIFF
--- a/Wino.Authentication/OutlookAuthenticator.cs
+++ b/Wino.Authentication/OutlookAuthenticator.cs
@@ -67,7 +67,8 @@ public class OutlookAuthenticator : BaseAuthenticator, IOutlookAuthenticator
     {
         await EnsureTokenCacheAttachedAsync();
 
-        var storedAccount = (await _publicClientApplication.GetAccountsAsync()).FirstOrDefault(a => a.Username == account.Address);
+        var storedAccount = (await _publicClientApplication.GetAccountsAsync()).FirstOrDefault(
+            a => string.Equals(a.Username?.Trim(), account.Address?.Trim(), StringComparison.OrdinalIgnoreCase));
 
         if (storedAccount == null)
             return await GenerateTokenInformationAsync(account);


### PR DESCRIPTION
Issue: Account selector dialog pops up endlessly for Outlook/Live accounts. (Stored account not being correctly identified)

Fix: Ignore case differences, add null safety and remove whitespaces when retrieving stored accounts.