### PR TITLE
feat(notification): ✨ Remove notification when read externally

### DIFF
--- a/Wino.Core.Domain/Interfaces/INotificationBuilder.cs
+++ b/Wino.Core.Domain/Interfaces/INotificationBuilder.cs
@@ -22,4 +22,9 @@ public interface INotificationBuilder
     /// Creates test notification for test purposes.
     /// </summary>
     Task CreateTestNotificationAsync(string title, string message);
+
+    /// <summary>
+    /// Removes the toast notification for a specific mail by unique id.
+    /// </summary>
+    Task RemoveNotificationAsync(Guid mailUniqueId);
 }

--- a/Wino.Core.Domain/Interfaces/INotificationBuilder.cs
+++ b/Wino.Core.Domain/Interfaces/INotificationBuilder.cs
@@ -26,5 +26,5 @@ public interface INotificationBuilder
     /// <summary>
     /// Removes the toast notification for a specific mail by unique id.
     /// </summary>
-    Task RemoveNotificationAsync(Guid mailUniqueId);
+    void RemoveNotification(Guid mailUniqueId);
 }

--- a/Wino.Core.UWP/Services/NotificationBuilder.cs
+++ b/Wino.Core.UWP/Services/NotificationBuilder.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.WinUI.Notifications;
 using Serilog;
 using Windows.Data.Xml.Dom;
@@ -11,8 +13,6 @@ using Wino.Core.Domain.Entities.Mail;
 using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Models.MailItem;
-using System.IO;
-using CommunityToolkit.Mvvm.Messaging;
 using Wino.Messaging.UI;
 
 namespace Wino.Core.UWP.Services;
@@ -39,9 +39,9 @@ public class NotificationBuilder : INotificationBuilder
         _mailService = mailService;
         _thumbnailService = thumbnailService;
 
-        WeakReferenceMessenger.Default.Register<MailReadStatusChanged>(this, async (r, msg) =>
+        WeakReferenceMessenger.Default.Register<MailReadStatusChanged>(this, (r, msg) =>
         {
-            await RemoveNotificationAsync(msg.UniqueId);
+            RemoveNotification(msg.UniqueId);
         });
     }
 
@@ -243,7 +243,7 @@ public class NotificationBuilder : INotificationBuilder
         //await Task.CompletedTask;
     }
 
-    public async Task RemoveNotificationAsync(Guid mailUniqueId)
+    public void RemoveNotification(Guid mailUniqueId)
     {
         try
         {
@@ -253,6 +253,5 @@ public class NotificationBuilder : INotificationBuilder
         {
             Log.Error(ex, $"Failed to remove notification for mail {mailUniqueId}");
         }
-        await Task.CompletedTask;
     }
 }

--- a/Wino.Core.UWP/Services/NotificationBuilder.cs
+++ b/Wino.Core.UWP/Services/NotificationBuilder.cs
@@ -81,7 +81,11 @@ public class NotificationBuilder : INotificationBuilder
                 foreach (var mailItem in validItems)
                 {
                     if (mailItem.IsRead)
+                    {
+                        // Remove the notification for a specific mail if it exists
+                        ToastNotificationManager.History.Remove(mailItem.UniqueId.ToString());
                         continue;
+                    }
 
                     var builder = new ToastContentBuilder();
                     builder.SetToastScenario(ToastScenario.Default);
@@ -117,7 +121,8 @@ public class NotificationBuilder : INotificationBuilder
                         Src = new Uri("ms-winsoundevent:Notification.Mail")
                     });
 
-                    builder.Show();
+                    // Use UniqueId as tag to allow removal
+                    builder.Show(toast => toast.Tag = mailItem.UniqueId.ToString());
                 }
 
                 await UpdateTaskbarIconBadgeAsync();
@@ -229,5 +234,18 @@ public class NotificationBuilder : INotificationBuilder
         //builder.Show();
 
         //await Task.CompletedTask;
+    }
+
+    public async Task RemoveNotificationAsync(Guid mailUniqueId)
+    {
+        try
+        {
+            ToastNotificationManager.History.Remove(mailUniqueId.ToString());
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed to remove notification for mail {mailUniqueId}");
+        }
+        await Task.CompletedTask;
     }
 }

--- a/Wino.Core.UWP/Services/NotificationBuilder.cs
+++ b/Wino.Core.UWP/Services/NotificationBuilder.cs
@@ -12,6 +12,8 @@ using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Models.MailItem;
 using System.IO;
+using CommunityToolkit.Mvvm.Messaging;
+using Wino.Messaging.UI;
 
 namespace Wino.Core.UWP.Services;
 
@@ -36,6 +38,12 @@ public class NotificationBuilder : INotificationBuilder
         _folderService = folderService;
         _mailService = mailService;
         _thumbnailService = thumbnailService;
+
+        // Listener per evento MailReadStatusChanged
+        WeakReferenceMessenger.Default.Register<MailReadStatusChanged>(this, async (r, msg) =>
+        {
+            await RemoveNotificationAsync(msg.UniqueId);
+        });
     }
 
     public async Task CreateNotificationsAsync(Guid inboxFolderId, IEnumerable<IMailItem> downloadedMailItems)

--- a/Wino.Core.UWP/Services/NotificationBuilder.cs
+++ b/Wino.Core.UWP/Services/NotificationBuilder.cs
@@ -39,7 +39,6 @@ public class NotificationBuilder : INotificationBuilder
         _mailService = mailService;
         _thumbnailService = thumbnailService;
 
-        // Listener per evento MailReadStatusChanged
         WeakReferenceMessenger.Default.Register<MailReadStatusChanged>(this, async (r, msg) =>
         {
             await RemoveNotificationAsync(msg.UniqueId);

--- a/Wino.Mail.ViewModels/AppShellViewModel.cs
+++ b/Wino.Mail.ViewModels/AppShellViewModel.cs
@@ -1076,4 +1076,14 @@ public partial class AppShellViewModel : MailBaseViewModel,
     {
         await MenuItemInvokedOrSelectedAsync(SettingsItem, WinoPage.AppPreferencesPage);
     }
+
+    protected override async void OnMailUpdated(MailCopy updatedMail)
+    {
+        base.OnMailUpdated(updatedMail);
+
+        if (updatedMail.IsRead && updatedMail.UniqueId != Guid.Empty)
+        {
+            await _notificationBuilder.RemoveNotificationAsync(updatedMail.UniqueId);
+        }
+    }
 }

--- a/Wino.Mail.ViewModels/AppShellViewModel.cs
+++ b/Wino.Mail.ViewModels/AppShellViewModel.cs
@@ -1076,14 +1076,4 @@ public partial class AppShellViewModel : MailBaseViewModel,
     {
         await MenuItemInvokedOrSelectedAsync(SettingsItem, WinoPage.AppPreferencesPage);
     }
-
-    protected override async void OnMailUpdated(MailCopy updatedMail)
-    {
-        base.OnMailUpdated(updatedMail);
-
-        if (updatedMail.IsRead && updatedMail.UniqueId != Guid.Empty)
-        {
-            await _notificationBuilder.RemoveNotificationAsync(updatedMail.UniqueId);
-        }
-    }
 }

--- a/Wino.Messages/UI/MailReadStatusChanged.cs
+++ b/Wino.Messages/UI/MailReadStatusChanged.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace Wino.Messaging.UI;
+
+public record MailReadStatusChanged(Guid UniqueId);

--- a/Wino.Services/MailService.cs
+++ b/Wino.Services/MailService.cs
@@ -17,6 +17,8 @@ using Wino.Core.Domain.Models.Comparers;
 using Wino.Core.Domain.Models.MailItem;
 using Wino.Messaging.UI;
 using Wino.Services.Extensions;
+using CommunityToolkit.Mvvm.Messaging;
+using Wino.Messaging.UI; // Per MailReadStatusChanged
 
 namespace Wino.Services;
 
@@ -584,6 +586,11 @@ public class MailService : BaseDatabaseService, IMailService
             if (item.IsRead == isRead) return false;
 
             item.IsRead = isRead;
+            if (isRead && item.UniqueId != Guid.Empty)
+            {
+                // Invia evento tramite Messenger
+                WeakReferenceMessenger.Default.Send(new MailReadStatusChanged(item.UniqueId));
+            }
 
             return true;
         });

--- a/Wino.Services/MailService.cs
+++ b/Wino.Services/MailService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
 using MimeKit;
 using Serilog;
 using SqlKata;
@@ -17,8 +18,6 @@ using Wino.Core.Domain.Models.Comparers;
 using Wino.Core.Domain.Models.MailItem;
 using Wino.Messaging.UI;
 using Wino.Services.Extensions;
-using CommunityToolkit.Mvvm.Messaging;
-using Wino.Messaging.UI; // Per MailReadStatusChanged
 
 namespace Wino.Services;
 

--- a/Wino.Services/MailService.cs
+++ b/Wino.Services/MailService.cs
@@ -588,7 +588,6 @@ public class MailService : BaseDatabaseService, IMailService
             item.IsRead = isRead;
             if (isRead && item.UniqueId != Guid.Empty)
             {
-                // Invia evento tramite Messenger
                 WeakReferenceMessenger.Default.Send(new MailReadStatusChanged(item.UniqueId));
             }
 


### PR DESCRIPTION
Implemented a new method `RemoveNotificationAsync` in the `INotificationBuilder` interface to allow the removal of toast notifications for specific emails identified by a unique ID.

This change enhances the notification management by ensuring that notifications can be cleared when emails are marked as read. The `NotificationBuilder` class has been updated to include logic for removing existing notifications and to use the unique ID as a tag for the toast notifications, facilitating their removal. Additionally, the `AppShellViewModel` has been modified to call this new method when an email is updated and marked as read.

This improvement aims to provide a better user experience by keeping the notification area relevant and up-to-date.