### PR TITLE
fix: Remove top from outlook requests

### DIFF
--- a/Wino.Core/Synchronizers/OutlookSynchronizer.cs
+++ b/Wino.Core/Synchronizers/OutlookSynchronizer.cs
@@ -246,7 +246,6 @@ public class OutlookSynchronizer : WinoSynchronizer<RequestInformation, Message,
 
             messageCollectionPage = await _graphClient.Me.MailFolders[folder.RemoteFolderId].Messages.Delta.GetAsDeltaGetResponseAsync((config) =>
            {
-               config.QueryParameters.Top = (int)InitialMessageDownloadCountPerFolder;
                config.QueryParameters.Select = outlookMessageSelectParameters;
                config.QueryParameters.Orderby = ["receivedDateTime desc"];
            }, cancellationToken).ConfigureAwait(false);
@@ -257,7 +256,6 @@ public class OutlookSynchronizer : WinoSynchronizer<RequestInformation, Message,
 
             var requestInformation = _graphClient.Me.MailFolders[folder.RemoteFolderId].Messages.Delta.ToGetRequestInformation((config) =>
             {
-                config.QueryParameters.Top = (int)InitialMessageDownloadCountPerFolder;
                 config.QueryParameters.Select = outlookMessageSelectParameters;
                 config.QueryParameters.Orderby = ["receivedDateTime desc"];
             });


### PR DESCRIPTION
The Microosft Graph Delta API has a strange behaviour: it returns only 10 elements per page up to the $top value. This is in contrast with other API endpoints that create pages of $top elements each. So, leaving $top in delta requests means up to 250 elements per folder are synchronized (and older messages are never downloaded)