### PR TITLE
fix: QRESYNC initial modseq should be 1

### DIFF
--- a/Wino.Core/Synchronizers/ImapSync/QResyncSynchronizer.cs
+++ b/Wino.Core/Synchronizers/ImapSync/QResyncSynchronizer.cs
@@ -61,6 +61,9 @@ internal class QResyncSynchronizer : ImapSynchronizationStrategyBase
 
             // Perform QRESYNC synchronization.
             var localHighestModSeq = (ulong)folder.HighestModeSeq;
+            // HIGHESTMODSEQ must be a positive integer, 0 is illegal.
+            // It's harmless to set it to 1, as RFC-compliant server without mod-seq would ignore this parameter.
+            if (localHighestModSeq == 0) localHighestModSeq = 1;
 
             remoteFolder.MessagesVanished += OnMessagesVanished;
             remoteFolder.MessageFlagsChanged += OnMessageFlagsChanged;
@@ -115,6 +118,7 @@ internal class QResyncSynchronizer : ImapSynchronizationStrategyBase
     internal override async Task<IList<UniqueId>> GetChangedUidsAsync(IImapClient client, IMailFolder remoteFolder, IImapSynchronizer synchronizer, CancellationToken cancellationToken = default)
     {
         var localHighestModSeq = (ulong)Folder.HighestModeSeq;
+        if (localHighestModSeq == 0) localHighestModSeq = 1;
         return await remoteFolder.SearchAsync(SearchQuery.ChangedSince(localHighestModSeq), cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
According to the RFC 7162, when synchronizing IMAP folder with `QRESYNC`, `MODSEQ` should be a positive integer, starting from 1.

This PR fixes non-complaint behavior which some mailservers (e.g. Mox) rejects (#656).

On it's own, this fix shouldn't break any existing behavior - any server that accepts `0` should also accept `1`, as that is a syntax rule ([RFC 7162, Section 7, mod-section-value](https://datatracker.ietf.org/doc/html/rfc7162#section-7)).
However, Wino treats any IMAP server that reports `QRESYNC` capability as one which supports storing persistent `MODSEQ` values. While this is true for most servers, there could be an edge case of a server that doesn't store `MODSEQ` values for some IMAP folders. Such server should reject any `MODSEQ`-based commands, like `SEARCH` or `FETCH`.
This could be fixed by adding a `MailItemFolder` attribute that would store if folder supports `MODSEQ` values, and if not, then UID-based sync strategy should be used instead of `QRESYNC` / `CONDSTORE` one. However, I don't have a server to test this additional check, so I'm leaving this as a comment, not as an implementation.

Tested on my own Mox mailserver - this fix allows me to fetch my messages instead of getting an empty inbox.
Mox version: `v0.0.15-0.20250407113542-902de0e1f957-go1.24.2`, `linux/amd64`.
