### PR TITLE
Add manual live ImapSynchronizer coverage tests

### DIFF
--- a/Wino.Core.Tests/Synchronizers/ImapSynchronizerLiveTests.cs
+++ b/Wino.Core.Tests/Synchronizers/ImapSynchronizerLiveTests.cs
@@ -10,10 +10,12 @@ using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Models.MailItem;
 using Wino.Core.Domain.Models.Synchronization;
 using Wino.Core.Integration.Processors;
+using Wino.Core.Requests.Mail;
 using Wino.Core.Synchronizers.ImapSync;
 using Wino.Core.Synchronizers.Mail;
 using Wino.Services.Extensions;
 using Xunit;
+using IMailService = Wino.Core.Domain.Interfaces.IMailService;
 
 namespace Wino.Core.Tests.Synchronizers;
 
@@ -243,7 +245,7 @@ public sealed class ImapSynchronizerLiveTests
         changeProcessor.Setup(x => x.GetRecentMailIdsForFolderAsync(inboxFolder.Id, It.IsAny<int>()))
             .ReturnsAsync((Guid _, int count) => storedMails.Keys.Take(count).ToList());
         changeProcessor.Setup(x => x.GetDownloadedUnreadMailsAsync(account.Id, It.IsAny<IEnumerable<string>>()))
-            .ReturnsAsync([] as List<MailCopy>);
+            .ReturnsAsync(new List<MailCopy>());
 
         var appConfiguration = new Mock<IApplicationConfiguration>();
         appConfiguration.SetupProperty(x => x.ApplicationDataFolderPath, tempDirectory);


### PR DESCRIPTION
## Summary
- added `ImapSynchronizerLiveTests` in `Wino.Core.Tests/Synchronizers/ImapSynchronizerLiveTests.cs`
- mirrored the CalDAV live-test pattern by using `[Fact(Skip = ...)]` with credential placeholders for server/port/username/password
- instantiated `ImapSynchronizer` with an IMAP4 `MailAccount` and lightweight in-memory mocked services so tests can be enabled and run manually

## Added live test scenarios
- Initial synchronization (Inbox metadata download)
- Delta synchronization (second sync run should download zero additional messages)
- Mark first Inbox message unread then read, verifying server `\Seen` state transitions
- Mark first Inbox message read then unread, verifying server `\Seen` state transitions

## Notes
- these are intentionally skipped by default and require updating placeholder connection values plus removing `Skip`
- local validation in this environment was limited because `dotnet` is not installed

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69984cfa6cb083328f2c979c4e150e5e)