### PR TITLE
Always register app notifications and target Mail/Calendar AppUserModelIds for toasts

### DIFF
--- a/Wino.Mail.WinUI/App.xaml.cs
+++ b/Wino.Mail.WinUI/App.xaml.cs
@@ -136,10 +136,8 @@ public partial class App : WinoApplication,
     {
         base.OnLaunched(args);
 
-        if (ShouldRegisterAppNotifications(args))
-        {
-            TryRegisterAppNotifications();
-        }
+        // Always register notification callbacks for both app entries (Mail and Calendar).
+        TryRegisterAppNotifications();
 
         // Initialize required services regardless of launch activation type.
         // All activation scenarios require these services to be ready.
@@ -189,28 +187,6 @@ public partial class App : WinoApplication,
 
     private async void AppNotificationInvoked(AppNotificationManager sender, AppNotificationActivatedEventArgs args)
         => await HandleToastActivationAsync(args);
-
-    private bool ShouldRegisterAppNotifications(Microsoft.UI.Xaml.LaunchActivatedEventArgs? args)
-    {
-        var activationArgs = AppInstance.GetCurrent().GetActivatedEventArgs();
-
-        // Always allow registration when activated from a toast.
-        if (activationArgs.Kind == ExtendedActivationKind.AppNotification)
-            return true;
-
-        var launchMode = AppModeActivationResolver.Resolve(args?.Arguments,
-                                                           GetCurrentLaunchTileId(),
-                                                           Environment.CommandLine,
-                                                           _preferencesService?.DefaultApplicationMode ?? WinoApplicationMode.Mail);
-        bool shouldRegister = launchMode == WinoApplicationMode.Mail;
-
-        if (!shouldRegister)
-        {
-            LogActivation("Skipping app notification registration for non-mail launch mode.");
-        }
-
-        return shouldRegister;
-    }
 
     private void TryRegisterAppNotifications()
     {

--- a/Wino.Mail.WinUI/Services/NotificationBuilder.cs
+++ b/Wino.Mail.WinUI/Services/NotificationBuilder.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Toolkit.Uwp.Notifications;
 using Serilog;
+using Windows.ApplicationModel;
 using Windows.Data.Xml.Dom;
 using Windows.UI.Notifications;
 using Wino.Core.Domain.Entities.Calendar;
@@ -19,6 +20,9 @@ namespace Wino.Mail.WinUI.Services;
 
 public class NotificationBuilder : INotificationBuilder
 {
+    private const string MailApplicationId = "App";
+    private const string CalendarApplicationId = "CalendarApp";
+
     private readonly IAccountService _accountService;
     private readonly IFolderService _folderService;
     private readonly IMailService _mailService;
@@ -93,7 +97,7 @@ public class NotificationBuilder : INotificationBuilder
                     Src = new Uri("ms-winsoundevent:Notification.Mail")
                 });
 
-                builder.Show();
+                ShowToast(builder, ToastTargetApp.Mail);
             }
             else
             {
@@ -148,7 +152,7 @@ public class NotificationBuilder : INotificationBuilder
         });
 
         // Use UniqueId as tag to allow removal
-        builder.Show(toast => toast.Tag = mailItem.UniqueId.ToString());
+        ShowToast(builder, ToastTargetApp.Mail, mailItem.UniqueId.ToString());
     }
 
     private ToastButton GetDismissButton()
@@ -234,7 +238,7 @@ public class NotificationBuilder : INotificationBuilder
     {
         try
         {
-            ToastNotificationManager.History.Remove(mailUniqueId.ToString());
+            ToastNotificationManager.History.Remove(mailUniqueId.ToString(), null, GetAppUserModelId(ToastTargetApp.Mail));
         }
         catch (Exception ex)
         {
@@ -255,7 +259,7 @@ public class NotificationBuilder : INotificationBuilder
         builder.AddArgument(Constants.ToastMailAccountIdKey, account.Id.ToString());
         builder.AddArgument(Constants.ToastModeKey, Constants.ToastModeMail);
         builder.AddButton(new ToastButton().SetContent(Translator.Buttons_FixAccount));
-        builder.Show();
+        ShowToast(builder, ToastTargetApp.Mail);
     }
 
     public void CreateWebView2RuntimeMissingNotification()
@@ -268,7 +272,7 @@ public class NotificationBuilder : INotificationBuilder
 
         builder.AddButton(GetDismissButton());
         builder.AddArgument(Constants.ToastModeKey, Constants.ToastModeMail);
-        builder.Show();
+        ShowToast(builder, ToastTargetApp.Mail);
     }
 
     public Task CreateCalendarReminderNotificationAsync(CalendarItem calendarItem, long reminderDurationInSeconds)
@@ -301,8 +305,34 @@ public class NotificationBuilder : INotificationBuilder
         });
 
         var tag = $"calendar-reminder-{calendarItem.Id:N}-{reminderDurationInSeconds}";
-        builder.Show(toast => toast.Tag = tag);
+        ShowToast(builder, ToastTargetApp.Calendar, tag);
 
         return Task.CompletedTask;
+    }
+
+    private static void ShowToast(ToastContentBuilder builder, ToastTargetApp targetApp, string? tag = null)
+    {
+        var toastNotification = new ToastNotification(builder.GetToastContent().GetXml());
+
+        if (!string.IsNullOrWhiteSpace(tag))
+        {
+            toastNotification.Tag = tag;
+        }
+
+        var appUserModelId = GetAppUserModelId(targetApp);
+        var notifier = ToastNotificationManager.CreateToastNotifier(appUserModelId);
+        notifier.Show(toastNotification);
+    }
+
+    private static string GetAppUserModelId(ToastTargetApp targetApp)
+    {
+        var appId = targetApp == ToastTargetApp.Mail ? MailApplicationId : CalendarApplicationId;
+        return $"{Package.Current.Id.FamilyName}!{appId}";
+    }
+
+    private enum ToastTargetApp
+    {
+        Mail,
+        Calendar
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure notification callbacks are always registered so both Mail and Calendar entries receive activation events regardless of launch mode.
- Route toast creation and history manipulation to the correct AppUserModelId so notifications are shown/removed under the intended app identity (Mail vs Calendar).

### Description

- Removed conditional registration logic and always call `TryRegisterAppNotifications()` on launch so notification callbacks are registered for all activation scenarios. 
- Introduced `ShowToast` helper, `GetAppUserModelId`, `ToastTargetApp` enum, and constants for `MailApplicationId` and `CalendarApplicationId` to create and show `ToastNotification` objects using `ToastNotificationManager.CreateToastNotifier(appUserModelId)`. 
- Replaced direct `ToastContentBuilder.Show()` calls with `ShowToast(...)` for Mail and Calendar targets, and changed tag setting flow to pass `tag` into `ShowToast`. 
- Updated `RemoveNotification` to call `ToastNotificationManager.History.Remove(..., appUserModelId)` so removal is scoped to the correct AppUserModelId. 
- Added `using Windows.ApplicationModel;` to access `Package.Current.Id.FamilyName` for composing the AppUserModelId string.

### Testing

- Performed a solution build with `dotnet build` and the build completed successfully. 
- Ran project unit tests with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e340c73608332bbda256494eeccfc)