### PR TITLE
Add PR GitHub Actions workflow to build WinUI and run Core tests on Windows

### DIFF
--- a/.github/workflows/pr-winui-build.yml
+++ b/.github/workflows/pr-winui-build.yml
@@ -38,7 +38,7 @@ jobs:
         run: dotnet restore Wino.Mail.WinUI/Wino.Mail.WinUI.csproj --configfile nuget.config -p:Platform=${{ matrix.platform }} -p:RuntimeIdentifier=${{ matrix.rid }}
 
       - name: Build WinUI project
-        run: dotnet build Wino.Mail.WinUI/Wino.Mail.WinUI.csproj --configuration Release --no-restore -p:Platform=${{ matrix.platform }} -p:RuntimeIdentifier=${{ matrix.rid }}
+        run: dotnet build Wino.Mail.WinUI/Wino.Mail.WinUI.csproj --configuration Release --no-restore -p:Platform=${{ matrix.platform }} -p:RuntimeIdentifier=${{ matrix.rid }} -p:GenerateAppxPackageOnBuild=false -p:AppxPackageSigningEnabled=false
 
   core-tests:
     name: Run Core tests


### PR DESCRIPTION
### Motivation

- Add CI validation for pull requests that builds the WinUI app and runs core unit tests on Windows to catch regressions early.
- Ensure PRs (non-draft) exercise the Windows-specific WinUI build and the shared Core test suites before review.

### Description

- Add a new workflow file `/.github/workflows/pr-winui-build.yml` that triggers on `pull_request` events (`opened`, `synchronize`, `reopened`, `ready_for_review`).
- Create a job `build-winui-and-core-tests` that runs on `windows-latest` and only executes for non-draft PRs via `if: github.event.pull_request.draft == false`.
- The job checks out the repo with `actions/checkout@v4`, sets up the .NET SDK with `actions/setup-dotnet@v4` (`dotnet-version: 10.0.x`), restores and builds the `Wino.Mail.WinUI/Wino.Mail.WinUI.csproj` using `dotnet restore` and `dotnet build`, and then restores and runs all `*Core*.Tests.csproj` projects found recursively using PowerShell and `dotnet test`.

### Testing

- No automated tests were executed as part of this change; the added workflow will run the WinUI build and Core test projects on subsequent non-draft PRs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a16e6d48388332b631c52037c43158)