### PR TITLE
Replace W initials with accent-colored person icon when signed out

### DIFF
--- a/Wino.Mail.WinUI/ShellWindow.xaml
+++ b/Wino.Mail.WinUI/ShellWindow.xaml
@@ -146,11 +146,25 @@
                                 </Grid>
                             </Flyout>
                         </Button.Flyout>
-                        <PersonPicture
-                            x:Name="WinoAccountButtonPicture"
-                            Width="30"
-                            Height="30"
-                            Initials="W" />
+                        <Grid>
+                            <PersonPicture
+                                x:Name="WinoAccountButtonPicture"
+                                Width="30"
+                                Height="30"
+                                Initials="W"
+                                Visibility="Collapsed" />
+                            <Border
+                                x:Name="WinoAccountSignedOutIcon"
+                                Width="30"
+                                Height="30"
+                                Background="{ThemeResource AccentFillColorDefaultBrush}"
+                                CornerRadius="15">
+                                <FontIcon
+                                    FontSize="16"
+                                    Foreground="White"
+                                    Glyph="&#xE77B;" />
+                            </Border>
+                        </Grid>
                     </Button>
                 </StackPanel>
             </TitleBar.RightHeader>

--- a/Wino.Mail.WinUI/ShellWindow.xaml.cs
+++ b/Wino.Mail.WinUI/ShellWindow.xaml.cs
@@ -372,6 +372,9 @@ public sealed partial class ShellWindow : WindowEx, IWinoShellWindow,
         WinoAccountSignedOutView.Visibility = isSignedIn ? Visibility.Collapsed : Visibility.Visible;
         WinoAccountSignedInView.Visibility = isSignedIn ? Visibility.Visible : Visibility.Collapsed;
 
+        WinoAccountButtonPicture.Visibility = isSignedIn ? Visibility.Visible : Visibility.Collapsed;
+        WinoAccountSignedOutIcon.Visibility = isSignedIn ? Visibility.Collapsed : Visibility.Visible;
+
         var initials = GetInitials(account?.Email);
 
         WinoAccountButtonPicture.Initials = initials;


### PR DESCRIPTION
## Changes

- Updated ShellWindow.xaml to replace the bland "W" initials with an accent-colored person icon for the signed-out state
- Wrapped PersonPicture in a Grid container with a new Border element containing a FontIcon
- The new icon uses the AccentFillColorDefaultBrush for visual consistency
- Updated ShellWindow.xaml.cs to toggle visibility between the PersonPicture and signed-out icon based on authentication state

## Details

- PersonPicture is now collapsed when signed out
- New accent-colored circular Border with person icon (Glyph &#xE77B;) displays when signed out
- Proper visibility bindings ensure the correct UI element displays based on sign-in status