### PR TITLE
Fix Gmail sign-in not launching the browser on WinUI 3

### DIFF
--- a/Wino.Authentication/GmailAuthenticator.cs
+++ b/Wino.Authentication/GmailAuthenticator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Util.Store;
 using Wino.Core.Domain.Entities.Shared;
@@ -12,8 +13,11 @@ namespace Wino.Authentication;
 
 public class GmailAuthenticator : BaseAuthenticator, IGmailAuthenticator
 {
-    public GmailAuthenticator(IAuthenticatorConfig authConfig) : base(authConfig)
+    private readonly INativeAppService _nativeAppService;
+
+    public GmailAuthenticator(IAuthenticatorConfig authConfig, INativeAppService nativeAppService) : base(authConfig)
     {
+        _nativeAppService = nativeAppService;
     }
 
     public string ClientId => AuthenticatorConfig.GmailAuthenticatorClientId;
@@ -47,10 +51,19 @@ public class GmailAuthenticator : BaseAuthenticator, IGmailAuthenticator
 
     private Task<UserCredential> GetGoogleUserCredentialAsync(MailAccount account)
     {
-        return GoogleWebAuthorizationBroker.AuthorizeAsync(new ClientSecrets()
+        // Mirrors GoogleWebAuthorizationBroker.AuthorizeAsync but injects a code receiver that opens
+        // the browser via Windows.System.Launcher. The broker's default LocalServerCodeReceiver opens
+        // the browser with "cmd /c start", which silently fails inside the packaged WinUI 3 app and
+        // leaves authentication hanging forever. See WinoGmailCodeReceiver.
+        var flow = new GoogleAuthorizationCodeFlow(new GoogleAuthorizationCodeFlow.Initializer
         {
-            ClientId = ClientId
-        }, AuthenticatorConfig.GetGmailScope(account?.IsMailAccessGranted != false, account?.IsCalendarAccessGranted == true), GetCredentialKey(account), CancellationToken.None, new FileDataStore(AuthenticatorConfig.GmailTokenStoreIdentifier));
+            ClientSecrets = new ClientSecrets { ClientId = ClientId },
+            Scopes = AuthenticatorConfig.GetGmailScope(account?.IsMailAccessGranted != false, account?.IsCalendarAccessGranted == true),
+            DataStore = new FileDataStore(AuthenticatorConfig.GmailTokenStoreIdentifier)
+        });
+
+        return new AuthorizationCodeInstalledApp(flow, new WinoGmailCodeReceiver(_nativeAppService))
+            .AuthorizeAsync(GetCredentialKey(account), CancellationToken.None);
     }
 
     public Task DeleteTokenInformationAsync(MailAccount account)

--- a/Wino.Authentication/WinoGmailCodeReceiver.cs
+++ b/Wino.Authentication/WinoGmailCodeReceiver.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using Google.Apis.Auth.OAuth2;
+using Wino.Core.Domain.Interfaces;
+
+namespace Wino.Authentication;
+
+/// <summary>
+/// Local loopback OAuth code receiver for Gmail that opens the system browser through
+/// <see cref="INativeAppService.LaunchUriAsync"/>.
+///
+/// The base class opens the browser with "cmd /c start"; inside a packaged WinUI 3 (MSIX) process
+/// that shell-out - like a direct ShellExecute or Windows.System.Launcher - silently reports success
+/// but launches no browser, so <see cref="GoogleWebAuthorizationBroker"/> blocks forever on the
+/// loopback listener and the "Authenticating" step hangs. <see cref="INativeAppService.LaunchUriAsync"/>
+/// launches the resolved default-browser executable directly, which works from the packaged host.
+/// </summary>
+internal sealed class WinoGmailCodeReceiver : LocalServerCodeReceiver
+{
+    private readonly INativeAppService _nativeAppService;
+
+    public WinoGmailCodeReceiver(INativeAppService nativeAppService)
+    {
+        _nativeAppService = nativeAppService;
+    }
+
+    protected override bool OpenBrowser(string url)
+    {
+        // Must not block: the broker can invoke this on the UI thread. Launch on a background thread
+        // and return immediately; the base receiver then awaits the loopback redirect.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                if (!await _nativeAppService.LaunchUriAsync(new Uri(url)))
+                    Serilog.Log.Error("[GmailAuth] Could not open the Gmail authorization URL in a browser.");
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Error(ex, "[GmailAuth] Failed to open the Gmail authorization URL.");
+            }
+        });
+
+        return true;
+    }
+}

--- a/Wino.Core/Services/AuthenticationProvider.cs
+++ b/Wino.Core/Services/AuthenticationProvider.cs
@@ -28,7 +28,7 @@ public class AuthenticationProvider : IAuthenticationProvider
         return providerType switch
         {
             MailProviderType.Outlook => new OutlookAuthenticator(_nativeAppService, _applicationConfiguration, _authenticatorConfig),
-            MailProviderType.Gmail => new GmailAuthenticator(_authenticatorConfig),
+            MailProviderType.Gmail => new GmailAuthenticator(_authenticatorConfig, _nativeAppService),
             _ => throw new ArgumentException(Translator.Exception_UnsupportedProvider),
         };
     }

--- a/Wino.Mail.WinUI/Services/NativeAppService.cs
+++ b/Wino.Mail.WinUI/Services/NativeAppService.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Win32;
 using Windows.ApplicationModel;
 using Windows.Storage;
 using Windows.System;
@@ -76,7 +79,116 @@ public class NativeAppService : INativeAppService, IAppMetadataService
         await Launcher.LaunchFileAsync(file);
     }
 
-    public Task<bool> LaunchUriAsync(Uri uri) => Launcher.LaunchUriAsync(uri).AsTask();
+    public async Task<bool> LaunchUriAsync(Uri uri)
+    {
+        // The http/https default handler (e.g. Edge) is a Win32 desktop app. Inside this packaged,
+        // self-contained WinUI 3 host the shell-activation path that Launcher.LaunchUriAsync and
+        // ShellExecute funnel through silently no-ops (the API reports success but no browser opens),
+        // which breaks Gmail OAuth and any other "open in browser" action. For web URLs, launch the
+        // resolved default-browser executable directly via CreateProcess, which bypasses shell
+        // activation entirely. Other schemes (mailto:, ms-windows-store:, custom protocols) keep
+        // using the OS launcher.
+        if (uri.IsAbsoluteUri
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            && TryLaunchDefaultBrowser(uri))
+        {
+            return true;
+        }
+
+        try
+        {
+            return await Launcher.LaunchUriAsync(uri);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryLaunchDefaultBrowser(Uri uri)
+    {
+        try
+        {
+            var command = GetDefaultBrowserCommand();
+            if (string.IsNullOrEmpty(command))
+                return false;
+
+            // Split the registered "shell\open\command" into executable + argument template.
+            string executable;
+            string argumentTemplate;
+
+            if (command.StartsWith("\"", StringComparison.Ordinal))
+            {
+                var end = command.IndexOf('"', 1);
+                if (end < 0)
+                    return false;
+
+                executable = command.Substring(1, end - 1);
+                argumentTemplate = command.Substring(end + 1).Trim();
+            }
+            else
+            {
+                var space = command.IndexOf(' ');
+                executable = space < 0 ? command : command.Substring(0, space);
+                argumentTemplate = space < 0 ? string.Empty : command.Substring(space + 1).Trim();
+            }
+
+            // MSIX/Store browsers register an AppsFolder activation token rather than a real path;
+            // bail so the OS launcher fallback can handle those.
+            if (string.IsNullOrEmpty(executable) || !File.Exists(executable))
+                return false;
+
+            var url = uri.ToString();
+            var arguments = argumentTemplate.Contains("%1")
+                ? argumentTemplate.Replace("%1", url)
+                : argumentTemplate.Length > 0 ? $"{argumentTemplate} \"{url}\"" : $"\"{url}\"";
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = executable,
+                Arguments = arguments,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            return Process.Start(startInfo) != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string GetDefaultBrowserCommand()
+    {
+        var progId = ReadUserChoiceProgId("https") ?? ReadUserChoiceProgId("http");
+        if (string.IsNullOrEmpty(progId))
+            return null;
+
+        var commandSubKey = $"{progId}\\shell\\open\\command";
+
+        using (var key = Registry.CurrentUser.OpenSubKey($"Software\\Classes\\{commandSubKey}"))
+        {
+            if (key?.GetValue(null) is string perUserCommand && perUserCommand.Length > 0)
+                return perUserCommand;
+        }
+
+        using (var key = Registry.ClassesRoot.OpenSubKey(commandSubKey))
+        {
+            if (key?.GetValue(null) is string machineCommand && machineCommand.Length > 0)
+                return machineCommand;
+        }
+
+        return null;
+    }
+
+    private static string ReadUserChoiceProgId(string scheme)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(
+            $"Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\{scheme}\\UserChoice");
+
+        return key?.GetValue("ProgId") as string;
+    }
 
     public string GetFullAppVersion()
     {


### PR DESCRIPTION
## Problem

On the WinUI 3 build, adding a Gmail account hangs forever on **"Authenticating with Gmail"** — the system browser never opens, so OAuth can never complete. The old UWP version worked. This reproduces across multiple machines.

## Root cause

Gmail OAuth uses `GoogleWebAuthorizationBroker.AuthorizeAsync` (Google.Apis.Auth), whose `LocalServerCodeReceiver` opens the consent page with:

```csharp
Process.Start(new ProcessStartInfo("cmd", $"/c start \"\" \"{url}\"") { CreateNoWindow = true });
```

Inside the packaged (MSIX) WinUI 3 host that shell-activation path **silently no-ops** — it reports success but launches no browser — so the loopback `HttpListener` waits forever for a redirect that never arrives, and setup hangs on "Authenticating with Gmail".

`Process.Start(UseShellExecute=true)` and `Windows.System.Launcher.LaunchUriAsync` funnel through the **same** shell-activation primitive and fail identically (per Microsoft's `Launcher` docs, when the handler is a desktop app the URI goes through shell execution, and on failure *"the API will succeed and return FALSE"*). That's why every "open link in browser" action in the app was affected, not just Gmail.

Confirmed empirically: the flow reaches the receiver and starts the loopback listener (`System.Net.HttpListener` loads), but no browser opens and nothing is logged; from a non-packaged process the same URL opens the default browser fine, so the machine/association is healthy.

## Fix

Open web URLs by resolving the default browser's executable from the per-user `https` `UserChoice` ProgId in the registry and starting it **directly** with `UseShellExecute=false` (a plain `CreateProcess` with the URL as an argument), which bypasses the broken shell-activation layer.

- `NativeAppService.LaunchUriAsync` now does this for `http`/`https` URIs; other schemes (`mailto:`, `ms-windows-store:`, custom protocols) keep using `Windows.System.Launcher`. This fixes Gmail **and** the other in-app "open in browser" actions (About/Settings links, calendar `HtmlLink`, unsubscribe, meeting-join) that were broken by the same primitive.
- Gmail auth now builds the flow via `AuthorizationCodeInstalledApp` + a custom `LocalServerCodeReceiver` (`WinoGmailCodeReceiver`) that routes the launch through `INativeAppService.LaunchUriAsync` instead of the broker's default cmd-based launcher. The loopback redirect flow (which already works) is unchanged.

MSIX/Store-app default browsers (which register an AppsFolder activation token rather than a real exe path) fall through to the `Windows.System.Launcher` path.

## Testing

- Built `Wino.Mail.WinUI` (Debug, x64) and deployed locally.
- Added a Gmail account end-to-end: the default browser (Edge) opens the Google consent page, the loopback redirect completes, and the account is created and syncs.

## Notes

- No manifest, DI topology, or Google OAuth client changes required.
- The dormant `google.pw.oauth2` custom-protocol code (`GoogleAuthorizationRequest`) remains unused and untouched.
