### PR TITLE
Add semi-transparent overlay to OOBE when a wallpaper theme is active.

### DIFF
--- a/Wino.Mail.WinUI/AppThemes/Clouds.xaml
+++ b/Wino.Mail.WinUI/AppThemes/Clouds.xaml
@@ -18,6 +18,7 @@
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#4D0078D4</SolidColorBrush>
 
             <SolidColorBrush x:Key="CalendarSeperatorBrush">#222f3e</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#D9FFFFFF</SolidColorBrush>
         </ResourceDictionary>
         <ResourceDictionary x:Name="Dark">
             <SolidColorBrush x:Key="MailListHeaderBackgroundColor">#b2dffc</SolidColorBrush>
@@ -27,6 +28,7 @@
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#66399BFF</SolidColorBrush>
 
             <SolidColorBrush x:Key="CalendarSeperatorBrush">#222f3e</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#E61F1F1F</SolidColorBrush>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/Wino.Mail.WinUI/AppThemes/Custom.xaml
+++ b/Wino.Mail.WinUI/AppThemes/Custom.xaml
@@ -35,6 +35,7 @@
             <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
             <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground" Color="{StaticResource MainCustomThemeColor}" />
             <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="{StaticResource MainCustomThemeColor}" />
+            <SolidColorBrush x:Key="WelcomeOverlayBrush" Color="{StaticResource MainCustomThemeColor}" />
         </ResourceDictionary>
         <ResourceDictionary x:Name="Dark">
             <!--  Reading Page Date/Name Group Header Background  -->
@@ -54,6 +55,7 @@
             <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
             <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground" Color="{StaticResource MainCustomThemeColor}" />
             <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="{StaticResource MainCustomThemeColor}" />
+            <SolidColorBrush x:Key="WelcomeOverlayBrush" Color="{StaticResource MainCustomThemeColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/Wino.Mail.WinUI/AppThemes/Forest.xaml
+++ b/Wino.Mail.WinUI/AppThemes/Forest.xaml
@@ -16,6 +16,7 @@
             <SolidColorBrush x:Key="CalendarHoverHourBackgroundBrush">#4D00D608</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarWorkHourBackgroundBrush">#4D00D608</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#4D0078D4</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#D9FFFFFF</SolidColorBrush>
         </ResourceDictionary>
         <ResourceDictionary x:Name="Dark">
             <SolidColorBrush x:Key="MailListHeaderBackgroundColor">#59001C01</SolidColorBrush>
@@ -23,6 +24,7 @@
             <SolidColorBrush x:Key="CalendarHoverHourBackgroundBrush">#6600D608</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarWorkHourBackgroundBrush">#59001C01</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#66399BFF</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#E61F1F1F</SolidColorBrush>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/Wino.Mail.WinUI/AppThemes/Garden.xaml
+++ b/Wino.Mail.WinUI/AppThemes/Garden.xaml
@@ -17,6 +17,7 @@
             <SolidColorBrush x:Key="CalendarWorkHourBackgroundBrush">#59DCFAD8</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#4D0078D4</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSeperatorBrush">#576574</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#D9FFFFFF</SolidColorBrush>
         </ResourceDictionary>
 
         <!--  N/A. Light theme only.  -->
@@ -26,6 +27,7 @@
             <SolidColorBrush x:Key="CalendarHoverHourBackgroundBrush">#59576574</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarWorkHourBackgroundBrush">#59576574</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#66399BFF</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#E61F1F1F</SolidColorBrush>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/Wino.Mail.WinUI/AppThemes/Nighty.xaml
+++ b/Wino.Mail.WinUI/AppThemes/Nighty.xaml
@@ -17,6 +17,7 @@
             <SolidColorBrush x:Key="CalendarHoverHourBackgroundBrush">#59FDCB6E</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarWorkHourBackgroundBrush">#66FDCB6E</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#4D0078D4</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#D9FFFFFF</SolidColorBrush>
         </ResourceDictionary>
         <ResourceDictionary x:Name="Dark">
             <!--  Brushes  -->
@@ -25,6 +26,7 @@
             <SolidColorBrush x:Key="CalendarHoverHourBackgroundBrush">#4D13191F</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarWorkHourBackgroundBrush">#5413191F</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#66399BFF</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#E61F1F1F</SolidColorBrush>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/Wino.Mail.WinUI/AppThemes/Snowflake.xaml
+++ b/Wino.Mail.WinUI/AppThemes/Snowflake.xaml
@@ -17,6 +17,7 @@
             <SolidColorBrush x:Key="CalendarHoverHourBackgroundBrush">#59B0C6DD</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarWorkHourBackgroundBrush">#66B0C6DD</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#4D0078D4</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#D9FFFFFF</SolidColorBrush>
         </ResourceDictionary>
         <ResourceDictionary x:Name="Dark">
             <!--  Brushes  -->
@@ -25,6 +26,7 @@
             <SolidColorBrush x:Key="CalendarHoverHourBackgroundBrush">#59B0C6DD</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarWorkHourBackgroundBrush">#66B0C6DD</SolidColorBrush>
             <SolidColorBrush x:Key="CalendarSelectedHourBackgroundBrush">#66399BFF</SolidColorBrush>
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">#E61F1F1F</SolidColorBrush>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/Wino.Mail.WinUI/Styles/Colors.xaml
+++ b/Wino.Mail.WinUI/Styles/Colors.xaml
@@ -21,6 +21,7 @@
             <SolidColorBrush x:Key="SettingsPaneBorderBrush">#636e72</SolidColorBrush>
             <SolidColorBrush x:Key="WinoContentZoneBackgroud" Color="White" />
             <StaticResource x:Key="ReadingPaneBackgroundColorBrush" ResourceKey="WinoContentZoneBackgroud" />
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">Transparent</SolidColorBrush>
             <SolidColorBrush x:Key="MailItemFlaggedBackgroundBrush" Color="#ffffcc" />
             <SolidColorBrush x:Key="InformationBrush">#34495e</SolidColorBrush>
         </ResourceDictionary>
@@ -30,6 +31,7 @@
             <SolidColorBrush x:Key="SettingsPaneBorderBrush">#2d3436</SolidColorBrush>
             <StaticResource x:Key="WinoContentZoneBackgroud" ResourceKey="LayerFillColorDefaultBrush" />
             <StaticResource x:Key="ReadingPaneBackgroundColorBrush" ResourceKey="WinoContentZoneBackgroud" />
+            <SolidColorBrush x:Key="WelcomeOverlayBrush">Transparent</SolidColorBrush>
             <SolidColorBrush x:Key="MailItemFlaggedBackgroundBrush" Color="#576574" />
             <SolidColorBrush x:Key="InformationBrush">#ecf0f1</SolidColorBrush>
         </ResourceDictionary>

--- a/Wino.Mail.WinUI/WelcomeWindow.xaml
+++ b/Wino.Mail.WinUI/WelcomeWindow.xaml
@@ -9,6 +9,7 @@
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource WinoApplicationBackgroundColor}">
+        <Border Background="{ThemeResource WelcomeOverlayBrush}" />
         <Frame x:Name="RootFrame" />
     </Grid>
 </winuiex:WindowEx>


### PR DESCRIPTION
Fixes https://github.com/bkaankose/Wino-Mail/issues/985

## Summary

When the OOBE is re-triggered (e.g. after deleting the last account) with a wallpaper theme active, controls are nearly unreadable because they render directly on top of the wallpaper image.

This adds a `WelcomeOverlayBrush` theme resource:
- Non-wallpaper themes (Default, Acrylic): `Transparent` — no visual change
- Wallpaper themes: semi-transparent overlay (Light `#D9FFFFFF`, Dark `#E61F1F1F`)

A `Border` using this brush is placed between the wallpaper background and the OOBE content in `WelcomeWindow.xaml`.

## Test plan
- [ ] Set a wallpaper theme, delete last account → OOBE should be readable
- [ ] Verify Default/Mica theme OOBE is visually unchanged
- [ ] Verify Acrylic theme OOBE is visually unchanged