### PR TITLE
perf: avoid quadratic index rebuild in AddRangeAsync

### DIFF
--- a/Wino.Mail.ViewModels/Collections/WinoMailCollection.cs
+++ b/Wino.Mail.ViewModels/Collections/WinoMailCollection.cs
@@ -312,7 +312,8 @@ public class WinoMailCollection : ObservableRecipient, IRecipient<SelectedItemsC
                     var addResult = AddMailCore(item);
                     requiresFullRebuild |= addResult.RequiresFullGroupRebuild;
                     touchedItems.AddRange(addResult.TouchedItems);
-                    RebuildMailLookupIndexes();
+                    foreach (var touched in addResult.TouchedItems)
+                        IndexTopLevelItem(touched);
                 }
 
                 SortTopLevelItems();


### PR DESCRIPTION
## Summary

When switching between folders (e.g. Inbox ↔ Drafts), the mail list visibly rebuilds item by item instead of appearing instantly. This is especially noticeable compared to Windows Mail, where folder switching feels immediate.

## Root cause

`WinoMailCollection.AddRangeAsync()` called `RebuildMailLookupIndexes()` inside the per-item loop. This method clears all lookup dictionaries and re-indexes every item in the collection from scratch. For a folder with N mails, this resulted in 1+2+3+...+N = N(N+1)/2 index operations — **O(n²) complexity**.

For example, loading a folder with 50 mails performed ~1275 index operations instead of 50.

## Fix

Replace the full `RebuildMailLookupIndexes()` call inside the loop with incremental `IndexTopLevelItem()` calls for only the newly added/touched items. The existing full rebuild after the loop is kept for final cleanup. This reduces the loop from **O(n²) to O(n)**.

`IndexTopLevelItem()` already existed as the per-item building block used internally by `RebuildMailLookupIndexes()` — no new code was needed.

## Note

This change significantly improves folder switching speed, but it still doesn't match the near-instant feel of Windows Mail. Further improvements would likely require caching already-loaded folder contents or moving more work off the UI thread.