### PR TITLE
Mail UX fixes: composer overflow, compose flow, thread filtering

### DIFF
--- a/Wino.Mail.ViewModels/ComposePageViewModel.cs
+++ b/Wino.Mail.ViewModels/ComposePageViewModel.cs
@@ -1042,6 +1042,12 @@ public partial class ComposePageViewModel : MailBaseViewModel,
         if (CurrentMailDraftItem.MailCopy.UniqueId != removedMail.UniqueId)
             return;
 
+        // Only close when the user explicitly sent or discarded the draft.
+        // Sync-caused remove/add cycles (draft ID mapping) must not close
+        // the compose page.
+        if (!isUpdatingMimeBlocked)
+            return;
+
         await ExecuteUIThread(() => CloseRequested?.Invoke(this, EventArgs.Empty));
     }
 

--- a/Wino.Mail.ViewModels/MailAppShellViewModel.cs
+++ b/Wino.Mail.ViewModels/MailAppShellViewModel.cs
@@ -23,6 +23,7 @@ using Wino.Core.Domain.Models.Navigation;
 using Wino.Core.Domain.Models.Synchronization;
 using Wino.Core.Requests.Folder;
 using Wino.Core.Services;
+using Wino.Mail.ViewModels.Messages;
 using Wino.Mail.ViewModels.Data;
 using Wino.Messaging.Client.Accounts;
 using Wino.Messaging.Client.Navigation;
@@ -1118,9 +1119,6 @@ public partial class MailAppShellViewModel : MailBaseViewModel,
             return;
         }
 
-        // Navigate to draft folder.
-        await NavigateSpecialFolderAsync(account, SpecialFolderType.Draft, true);
-
         // Generate empty mime message.
         var draftOptions = new DraftCreationOptions
         {
@@ -1137,6 +1135,8 @@ public partial class MailAppShellViewModel : MailBaseViewModel,
 
         var draftPreparationRequest = new DraftPreparationRequest(account, draftMailCopy, draftBase64MimeMessage, draftOptions.Reason);
         await _winoRequestDelegator.ExecuteAsync(draftPreparationRequest);
+
+        Messenger.Send(new ActiveMailItemChangedEvent(new MailItemViewModel(draftMailCopy)));
     }
 
     public override async Task KeyboardShortcutHook(KeyboardShortcutTriggerDetails args)

--- a/Wino.Mail.ViewModels/MailListPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailListPageViewModel.cs
@@ -1520,7 +1520,7 @@ public partial class MailListPageViewModel : MailBaseViewModel,
     {
         base.OnDraftCreated(draftMail, account);
 
-        if (!BelongsToActiveFolder(draftMail)) return;
+        if (!BelongsToActiveFolder(draftMail) && !ShouldIncludeByThread(draftMail)) return;
 
         try
         {

--- a/Wino.Mail.ViewModels/MailListPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailListPageViewModel.cs
@@ -1001,7 +1001,15 @@ public partial class MailListPageViewModel : MailBaseViewModel,
     private bool ShouldIncludeByThread(MailCopy mailItem)
         => PreferencesService.IsThreadingEnabled
            && !string.IsNullOrEmpty(mailItem?.ThreadId)
-           && ThreadIdExistsInCollection(mailItem);
+           && ThreadIdExistsInCollection(mailItem)
+           && !IsExcludedFromThreadByFolder(mailItem);
+
+    private bool IsExcludedFromThreadByFolder(MailCopy mailItem)
+    {
+        if (mailItem?.AssignedFolder?.SpecialFolderType is SpecialFolderType.Deleted or SpecialFolderType.Junk)
+            return true;
+        return ActiveFolder?.SpecialFolderType is SpecialFolderType.Deleted or SpecialFolderType.Junk;
+    }
 
     private bool ShouldIncludeAddedMailInCurrentList(MailCopy addedMail)
     {

--- a/Wino.Mail.ViewModels/MailListPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailListPageViewModel.cs
@@ -1510,6 +1510,8 @@ public partial class MailListPageViewModel : MailBaseViewModel,
     {
         base.OnDraftCreated(draftMail, account);
 
+        if (!BelongsToActiveFolder(draftMail)) return;
+
         try
         {
             // If the draft is created in another folder, we need to wait for that folder to be initialized.

--- a/Wino.Mail.ViewModels/MailListPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailListPageViewModel.cs
@@ -852,6 +852,8 @@ public partial class MailListPageViewModel : MailBaseViewModel,
         var (draftMailCopy, draftBase64MimeMessage) = await _mailService.CreateDraftAsync(targetMail.MailCopy.AssignedAccount.Id, draftOptions).ConfigureAwait(false);
         var draftPreparationRequest = new DraftPreparationRequest(targetMail.MailCopy.AssignedAccount, draftMailCopy, draftBase64MimeMessage, draftOptions.Reason, targetMail.MailCopy);
         await _winoRequestDelegator.ExecuteAsync(draftPreparationRequest);
+
+        Messenger.Send(new ActiveMailItemChangedEvent(new MailItemViewModel(draftMailCopy)));
     }
 
     public IEnumerable<MailOperationMenuItem> GetAvailableMailActions(IEnumerable<MailItemViewModel> contextMailItems)

--- a/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
+++ b/Wino.Mail.ViewModels/MailRenderingPageViewModel.cs
@@ -26,6 +26,7 @@ using Wino.Core.Domain.Models.Printing;
 using Wino.Core.Domain.Models.Reader;
 using Wino.Core.Services;
 using Wino.Mail.ViewModels.Data;
+using Wino.Mail.ViewModels.Messages;
 using Wino.Mail.ViewModels.Models;
 using Wino.Messaging.Client.Mails;
 using Wino.Messaging.UI;
@@ -339,6 +340,8 @@ public partial class MailRenderingPageViewModel : MailBaseViewModel,
                 var draftPreparationRequest = new DraftPreparationRequest(initializedMailItemViewModel.MailCopy.AssignedAccount, draftMailCopy, draftBase64MimeMessage, draftOptions.Reason, initializedMailItemViewModel.MailCopy);
 
                 await _requestDelegator.ExecuteAsync(draftPreparationRequest);
+
+                Messenger.Send(new ActiveMailItemChangedEvent(new MailItemViewModel(draftMailCopy)));
                 ComposeRequested?.Invoke(this, new ComposeDraftRequestedEventArgs(draftMailCopy.UniqueId));
 
             }

--- a/Wino.Mail.WinUI/Controls/EditorTabbedCommandBarControl.xaml
+++ b/Wino.Mail.WinUI/Controls/EditorTabbedCommandBarControl.xaml
@@ -72,7 +72,10 @@
         </toolkit:TabbedCommandBar.Resources>
 
         <toolkit:TabbedCommandBar.PaneCustomContent>
-            <ContentPresenter Content="{x:Bind PaneCustomContent, Mode=OneWay}" />
+            <ContentPresenter
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
+                Content="{x:Bind PaneCustomContent, Mode=OneWay}" />
         </toolkit:TabbedCommandBar.PaneCustomContent>
 
         <toolkit:TabbedCommandBar.MenuItems>

--- a/Wino.Mail.WinUI/Views/Mail/ComposePage.xaml
+++ b/Wino.Mail.WinUI/Views/Mail/ComposePage.xaml
@@ -177,10 +177,13 @@
                 <controls1:EditorTabbedCommandBarControl CommandTarget="{x:Bind WebViewEditor}">
                     <controls1:EditorTabbedCommandBarControl.PaneCustomContent>
                         <toolkit:TabbedCommandBarItem
+                            x:Name="RightCommandBar"
+                            HorizontalAlignment="Stretch"
                             CommandAlignment="Right"
                             IsDynamicOverflowEnabled="True"
-                            OverflowButtonAlignment="Left">
-                            <AppBarElementContainer Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.AvailableEmailTemplates.Count), Mode=OneWay}">
+                            OverflowButtonAlignment="Left"
+                            OverflowButtonVisibility="Collapsed">
+                            <AppBarElementContainer DynamicOverflowOrder="5" Visibility="{x:Bind helpers:XamlHelpers.CountToVisibilityConverter(ViewModel.AvailableEmailTemplates.Count), Mode=OneWay}">
                                 <ComboBox
                                     AutomationProperties.AutomationId="EmailTemplatesComboBox"
                                     x:Name="EmailTemplatesComboBox"
@@ -207,10 +210,12 @@
                             <AppBarToggleButton
                                 AutomationProperties.AutomationId="ComposeAiActionsToggleButton"
                                 x:Name="ComposeAiActionsToggleButton"
+                                DynamicOverflowOrder="4"
                                 MinWidth="40"
                                 AutomationProperties.Name="{x:Bind domain:Translator.Composer_AiActions, Mode=OneTime}"
                                 HorizontalContentAlignment="Center"
                                 Checked="ComposeAiActionsToggleButton_Checked"
+                                Label="{x:Bind domain:Translator.Composer_AiActions, Mode=OneTime}"
                                 LabelPosition="Collapsed"
                                 ToolTipService.ToolTip="{x:Bind domain:Translator.Composer_AiActions}"
                                 Visibility="{x:Bind GetAiActionsToggleVisibility(ViewModel.PreferencesService.IsAiActionsPanelHidden), Mode=OneTime}">
@@ -221,7 +226,10 @@
                             <AppBarButton
                                 AutomationProperties.AutomationId="XBindDomainTranslatorButtonsPopOutModeOneTime"
                                 AutomationProperties.Name="{x:Bind domain:Translator.Buttons_PopOut, Mode=OneTime}"
+                                DynamicOverflowOrder="3"
                                 Click="PopOutButton_Click"
+                                Label="{x:Bind domain:Translator.Buttons_PopOut, Mode=OneTime}"
+                                LabelPosition="Collapsed"
                                 ToolTipService.ToolTip="{x:Bind domain:Translator.Buttons_PopOut}"
                                 Visibility="{x:Bind GetPopOutButtonVisibility(), Mode=OneWay}">
                                 <AppBarButton.Icon>
@@ -231,7 +239,10 @@
                             <AppBarButton
                                 AutomationProperties.AutomationId="XBindGetEditorThemeToolTipWebViewEditorIsEditorDarkModeModeOneWay"
                                 AutomationProperties.Name="{x:Bind GetEditorThemeToolTip(WebViewEditor.IsEditorDarkMode), Mode=OneWay}"
+                                DynamicOverflowOrder="2"
                                 Click="ToggleEditorThemeClicked"
+                                Label="{x:Bind GetEditorThemeToolTip(WebViewEditor.IsEditorDarkMode), Mode=OneWay}"
+                                LabelPosition="Collapsed"
                                 ToolTipService.ToolTip="{x:Bind GetEditorThemeToolTip(WebViewEditor.IsEditorDarkMode), Mode=OneWay}">
                                 <AppBarButton.Icon>
                                     <coreControls:WinoFontIcon Icon="{x:Bind GetEditorThemeIcon(WebViewEditor.IsEditorDarkMode), Mode=OneWay}" />
@@ -239,7 +250,7 @@
                             </AppBarButton>
                             <AppBarButton
 
-                                AutomationProperties.AutomationId="ComposePageAppBarButton2" Label="{x:Bind domain:Translator.MailOperation_SaveAs}">
+                                AutomationProperties.AutomationId="ComposePageAppBarButton2" DynamicOverflowOrder="1" Label="{x:Bind domain:Translator.MailOperation_SaveAs}">
                                 <AppBarButton.Icon>
                                     <coreControls:WinoFontIcon Icon="Save" />
                                 </AppBarButton.Icon>

--- a/Wino.Mail.WinUI/Views/Mail/ComposePage.xaml.cs
+++ b/Wino.Mail.WinUI/Views/Mail/ComposePage.xaml.cs
@@ -523,7 +523,39 @@ public sealed partial class ComposePage : ComposePageAbstract,
         {
             ToBox.Focus(FocusState.Programmatic);
         }
+
+        // Overflow-Button nur anzeigen, wenn tatsächlich Commands im Overflow-Menü liegen.
+        // Das native "Auto"-Verhalten blendet ihn an der Größen-Grenze fehlerhaft aus bzw.
+        // clippt ihn (zusammen mit der rechtsbündigen Ausrichtung der TabbedCommandBarItem).
+        RightCommandBar.DynamicOverflowItemsChanging -= RightCommandBar_DynamicOverflowItemsChanging;
+        RightCommandBar.DynamicOverflowItemsChanging += RightCommandBar_DynamicOverflowItemsChanging;
+        DispatcherQueue.TryEnqueue(UpdateOverflowButtonVisibility);
     }
+
+    private void RightCommandBar_DynamicOverflowItemsChanging(CommandBar sender, DynamicOverflowItemsChangingEventArgs args)
+        => DispatcherQueue.TryEnqueue(UpdateOverflowButtonVisibility);
+
+    private void UpdateOverflowButtonVisibility()
+    {
+        if (RightCommandBar is null) return;
+
+        var anyInOverflow = RightCommandBar.PrimaryCommands.Any(OverflowElementIsInOverflow);
+        var target = anyInOverflow
+            ? CommandBarOverflowButtonVisibility.Visible
+            : CommandBarOverflowButtonVisibility.Collapsed;
+
+        if (RightCommandBar.OverflowButtonVisibility != target)
+            RightCommandBar.OverflowButtonVisibility = target;
+    }
+
+    private static bool OverflowElementIsInOverflow(ICommandBarElement element) => element switch
+    {
+        AppBarButton b => b.IsInOverflow,
+        AppBarToggleButton t => t.IsInOverflow,
+        AppBarElementContainer c => c.IsInOverflow,
+        AppBarSeparator s => s.IsInOverflow,
+        _ => false
+    };
 
     private void CCBBCGotFocus(object sender, RoutedEventArgs e)
     {

--- a/Wino.Mail.WinUI/Views/Mail/MailListPage.xaml.cs
+++ b/Wino.Mail.WinUI/Views/Mail/MailListPage.xaml.cs
@@ -796,9 +796,11 @@ public sealed partial class MailListPage : MailListPageAbstract,
     {
         bool isMultiSelectionEnabled = ViewModel.IsMultiSelectionModeEnabled;
 
+        bool hasActiveContent = ViewModel.MailCollection.HasSingleItemSelected || IsComposingPageActive();
+
         if (StatePersistenceService.IsReaderNarrowed)
         {
-            if (ViewModel.MailCollection.HasSingleItemSelected && !isMultiSelectionEnabled)
+            if (hasActiveContent && !isMultiSelectionEnabled)
             {
                 VisualStateManager.GoToState(this, "NarrowRenderer", true);
             }
@@ -809,7 +811,7 @@ public sealed partial class MailListPage : MailListPageAbstract,
         }
         else
         {
-            if (ViewModel.MailCollection.HasSingleItemSelected && !isMultiSelectionEnabled)
+            if (hasActiveContent && !isMultiSelectionEnabled)
             {
                 VisualStateManager.GoToState(this, "BothPanelsMailSelected", true);
             }

--- a/Wino.Services/MailService.cs
+++ b/Wino.Services/MailService.cs
@@ -421,7 +421,10 @@ public class MailService : BaseDatabaseService, IMailService
         mails.RemoveAll(m => m.AssignedAccount == null || m.AssignedFolder == null);
         await _sentMailReceiptService.PopulateReceiptStatesAsync(mails).ConfigureAwait(false);
 
-        if (!options.CreateThreads || mails.Count == 0 || options.IsCategoryView)
+        bool isDeletedOrJunkView = options.Folders.Any(f =>
+            f.SpecialFolderType is SpecialFolderType.Deleted or SpecialFolderType.Junk);
+
+        if (!options.CreateThreads || mails.Count == 0 || options.IsCategoryView || isDeletedOrJunkView)
             return [.. mails];
 
         // 6. Expand threads: one batch query for all sibling mails across all threads.
@@ -472,7 +475,10 @@ public class MailService : BaseDatabaseService, IMailService
             }
 
             AssignPropertiesFromCaches(threadMails, folderCache, accountCache, contactCache);
-            mails.AddRange(threadMails.Where(m => m.AssignedAccount != null && m.AssignedFolder != null));
+            mails.AddRange(threadMails.Where(m =>
+                m.AssignedAccount != null
+                && m.AssignedFolder != null
+                && m.AssignedFolder.SpecialFolderType is not (SpecialFolderType.Deleted or SpecialFolderType.Junk)));
         }
 
         await _sentMailReceiptService.PopulateReceiptStatesAsync(mails).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

A set of small, self-contained UX fixes for Wino Mail. Each is an independent commit.

### Composer command bar
- **Reliable overflow.** The right-hand command bar (Send/Discard/…) ran off the window edge on narrow widths instead of moving buttons into the overflow menu, and the "…" button could disappear even while commands were still in the menu. Root cause: the `PaneCustomContent` host didn't stretch the CommandBar to the cell width, so overflow never triggered. Now stretched; the overflow button is driven by `IsInOverflow`; `DynamicOverflowOrder` keeps Send/Discard visible longest; icon-only buttons show their label in the overflow menu.

### Compose flow
- **Open composer without switching folders.** Creating a new mail no longer navigates away to Drafts; the composer opens while the current folder view stays put.
- **Keep composer open during sync.** A background sync no longer closes an open ComposePage.
- **Reflect the new draft.** `ActiveMailItemChangedEvent` is sent after draft creation so the composer reliably shows the new draft.
- **Reply draft in the active thread.** A reply draft now appears immediately in the thread it belongs to.

### Threading
- **Exclude Deleted/Junk from threading.** Deleted/Junk mails are no longer pulled into other folders' conversation threads.

> **Note:** Within the Deleted/Junk folders themselves, mails sharing a `ThreadId` are still grouped together; only cross-folder thread expansion is skipped. The intent is to keep deleted/junk mails out of *other* folders' threads, not to disable grouping inside the trash/junk view itself.