### PR TITLE
Fix duplicate copies of the same Gmail message inside a threaded conversation

### DIFF
--- a/src/Wino.Core.Domain/Extensions/MailCopyIdentityExtensions.cs
+++ b/src/Wino.Core.Domain/Extensions/MailCopyIdentityExtensions.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wino.Core.Domain.Entities.Mail;
+
+namespace Wino.Core.Domain.Extensions;
+
+/// <summary>
+/// Server message identity helpers.
+/// Gmail materializes one <see cref="MailCopy"/> row per label for the same server message:
+/// every row shares Id, ThreadId and FileId, and differs only in UniqueId and FolderId.
+/// Only one of those rows may ever be surfaced in a mail list.
+/// </summary>
+public static class MailCopyIdentityExtensions
+{
+    /// <summary>
+    /// Server message id, falling back to the local identity so rows without a server id
+    /// (local drafts, orphans) are never collapsed together.
+    /// </summary>
+    public static string ResolveServerMailId(this MailCopy mail)
+        => string.IsNullOrWhiteSpace(mail?.Id)
+            ? mail?.UniqueId.ToString("N") ?? string.Empty
+            : mail.Id;
+
+    /// <summary>
+    /// Account of the mail, preferring the hydrated account and falling back to a folder lookup
+    /// for copies that have not been hydrated yet.
+    /// </summary>
+    public static Guid ResolveAccountId(this MailCopy mail, IReadOnlyDictionary<Guid, Guid> accountIdsByFolderId)
+    {
+        if (mail?.AssignedAccount != null)
+            return mail.AssignedAccount.Id;
+
+        if (mail != null && accountIdsByFolderId != null && accountIdsByFolderId.TryGetValue(mail.FolderId, out var accountId))
+            return accountId;
+
+        return Guid.Empty;
+    }
+
+    /// <summary>
+    /// Collapses label siblings down to a single copy per (account, server message id).
+    /// </summary>
+    /// <param name="isPreferredCopy">
+    /// The caller's notion of "belongs to the surface being rendered". The copy that satisfies it
+    /// wins, because folder scoped actions and list seed checks must target the visible folder.
+    /// Gmail does not guarantee INBOX comes first in LabelIds, so insertion order cannot be trusted.
+    /// </param>
+    public static IEnumerable<MailCopy> CollapseServerMessageDuplicates(
+        this IEnumerable<MailCopy> mails,
+        IReadOnlyDictionary<Guid, Guid> accountIdsByFolderId,
+        Func<MailCopy, bool> isPreferredCopy)
+    {
+        ArgumentNullException.ThrowIfNull(mails);
+        ArgumentNullException.ThrowIfNull(isPreferredCopy);
+
+        return mails
+            .GroupBy(mail => (mail.ResolveAccountId(accountIdsByFolderId), mail.ResolveServerMailId()))
+            .Select(group => group
+                .OrderByDescending(isPreferredCopy)
+                .ThenByDescending(mail => mail.CreationDate)
+                .ThenBy(mail => mail.FolderId)
+                .ThenBy(mail => mail.UniqueId)
+                .First());
+    }
+}

--- a/src/Wino.Mail.ViewModels/Collections/MailListStore.cs
+++ b/src/Wino.Mail.ViewModels/Collections/MailListStore.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -48,6 +48,29 @@ public sealed class MailListStore
         !string.IsNullOrWhiteSpace(threadId) &&
         ((IEnumerable<MailItemViewModel>)Items).Any(
             item => string.Equals(item.ThreadKey, threadId, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Returns true when another copy of the same server message is already listed under a
+    /// different <see cref="MailCopy.UniqueId"/>. Gmail materializes one row per label, so a
+    /// single incoming message arrives as several rows that must not all be shown.
+    /// </summary>
+    public bool ContainsOtherServerMailCopy(MailCopy mailCopy)
+    {
+        if (mailCopy == null)
+            return false;
+
+        var accountId = mailCopy.AssignedAccount?.Id ?? Guid.Empty;
+        var serverMailId = mailCopy.Id;
+
+        // Fail open for rows we cannot identify, so nothing is ever hidden by accident.
+        if (accountId == Guid.Empty || string.IsNullOrWhiteSpace(serverMailId))
+            return false;
+
+        return ((IEnumerable<MailItemViewModel>)Items).Any(item =>
+            item.UniqueId != mailCopy.UniqueId &&
+            string.Equals(item.Id, serverMailId, StringComparison.Ordinal) &&
+            item.MailCopy?.AssignedAccount?.Id == accountId);
+    }
 
     public bool ContainsMailUniqueId(Guid uniqueId) => Items.ContainsId(uniqueId);
 

--- a/src/Wino.Mail.ViewModels/MailListPageViewModel.cs
+++ b/src/Wino.Mail.ViewModels/MailListPageViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -16,6 +16,7 @@ using Wino.Core.Domain;
 using Wino.Core.Domain.Entities.Mail;
 using Wino.Core.Domain.Entities.Shared;
 using Wino.Core.Domain.Enums;
+using Wino.Core.Domain.Extensions;
 using Wino.Core.Domain.Exceptions;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Models;
@@ -1440,7 +1441,10 @@ public partial class MailListPageViewModel : MailBaseViewModel,
     {
         if (!ShouldIncludeAddedMailInCurrentList(mail) ||
             ShouldPreventItemAdd(mail) ||
-            ShouldExcludeAddedMailByFocusedPivot(mail))
+            ShouldExcludeAddedMailByFocusedPivot(mail) ||
+            // Gmail lists the same server message once per label. If a sibling copy is already
+            // listed, this row is the same message and must not create a second one.
+            MailCollection.ContainsOtherServerMailCopy(mail))
         {
             return false;
         }
@@ -1979,10 +1983,14 @@ public partial class MailListPageViewModel : MailBaseViewModel,
                     .ConfigureAwait(false);
             }
 
+            // The whole batch is filtered before anything is added, so the collection guard inside
+            // ShouldIncludeLiveMail cannot see siblings that arrive together. Collapse the Gmail
+            // label rows here, preferring the copy that belongs to the listing being rendered.
             var mailsToAdd = targetMails
                 .Where(mail => !MailCollection.ContainsMailUniqueId(mail.UniqueId))
                 .Where(mail => !ShouldSuppressDraftAdd(mail))
                 .Where(ShouldIncludeLiveMail)
+                .CollapseServerMessageDuplicates(accountIdsByFolderId: null, MatchesActiveFolderOrCategory)
                 .ToList();
 
             if (mailsToAdd.Count == 0)

--- a/src/Wino.Services/MailService.cs
+++ b/src/Wino.Services/MailService.cs
@@ -359,14 +359,7 @@ public class MailService : BaseDatabaseService, IMailService
         }
 
         query = options.DeduplicateByServerId
-            ? query
-                .GroupBy(m => (ResolveMailAccountId(m, accountIdsByFolderId), ResolveServerMailId(m)))
-                .Select(group => group
-                    .OrderByDescending(m => allowedFolderIds.Contains(m.FolderId))
-                    .ThenByDescending(m => m.CreationDate)
-                    .ThenBy(m => m.FolderId)
-                    .ThenBy(m => m.UniqueId)
-                    .First())
+            ? query.CollapseServerMessageDuplicates(accountIdsByFolderId, m => allowedFolderIds.Contains(m.FolderId))
             : query
                 .GroupBy(m => m.UniqueId)
                 .Select(group => group.First());
@@ -394,20 +387,6 @@ public class MailService : BaseDatabaseService, IMailService
 
         return query.ToList();
     }
-
-    private static Guid ResolveMailAccountId(MailCopy mail, IReadOnlyDictionary<Guid, Guid> accountIdsByFolderId)
-    {
-        if (mail?.AssignedAccount != null)
-            return mail.AssignedAccount.Id;
-
-        if (mail != null && accountIdsByFolderId.TryGetValue(mail.FolderId, out var accountId))
-            return accountId;
-
-        return Guid.Empty;
-    }
-
-    private static string ResolveServerMailId(MailCopy mail)
-        => string.IsNullOrWhiteSpace(mail?.Id) ? mail?.UniqueId.ToString("N") ?? string.Empty : mail.Id;
 
     public async Task<MailFetchPage> FetchMailPageAsync(
         MailListInitializationOptions options,
@@ -572,6 +551,8 @@ public class MailService : BaseDatabaseService, IMailService
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        var didExpandThreads = false;
+
         if (options.CreateThreads && !options.IsCategoryView)
         {
             var threadIds = mails
@@ -594,6 +575,8 @@ public class MailService : BaseDatabaseService, IMailService
                     .Where(mail => mail != null && !existingIds.Contains(mail.UniqueId))
                     .DistinctBy(mail => mail.UniqueId)
                     .ToList();
+
+                didExpandThreads = true;
             }
         }
 
@@ -616,6 +599,21 @@ public class MailService : BaseDatabaseService, IMailService
             {
                 folderCache[folder.Id] = folder;
             }
+        }
+
+        if (didExpandThreads)
+        {
+            // Gmail keeps one MailCopy row per label, so thread expansion returns every label row of
+            // each sibling message. Collapse them down to a single copy per server message, preferring
+            // the copy that lives in the listed folders. This runs after the folder cache is resolved
+            // because expansion is not account scoped and siblings can live outside options.Folders.
+            var listedFolderIds = options.Folders
+                .Where(folder => folder != null)
+                .Select(folder => folder.Id)
+                .ToHashSet();
+            var accountIdsByFolderId = folderCache.ToDictionary(entry => entry.Key, entry => entry.Value.MailAccountId);
+
+            mails = [.. mails.CollapseServerMessageDuplicates(accountIdsByFolderId, mail => listedFolderIds.Contains(mail.FolderId))];
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -777,6 +775,8 @@ public class MailService : BaseDatabaseService, IMailService
         if (excludeMailIds.Count > 0)
         {
             var excludePlaceholders = string.Join(",", excludeMailIds.Select(_ => "?"));
+            // Only the seed rows are excluded here. Label siblings of non-seed messages are collapsed
+            // downstream in ExpandAndHydrateAsync, which can express the listed-folder preference.
             sql = $"SELECT MailCopy.* FROM MailCopy WHERE ThreadId IN ({threadPlaceholders}) AND Id NOT IN ({excludePlaceholders})";
             parameters.AddRange(excludeMailIds.Cast<object>());
         }

--- a/tests/Wino.Core.Tests/Services/MailCopyIdentityExtensionsTests.cs
+++ b/tests/Wino.Core.Tests/Services/MailCopyIdentityExtensionsTests.cs
@@ -19,7 +19,7 @@ public class MailCopyIdentityExtensionsTests
             Id = serverId,
             FolderId = folderId,
             ThreadId = "thread-1",
-            CreationDate = creationDate ?? new DateTime(2026, 8, 15, 12, 0, 0, DateTimeKind.Utc),
+            CreationDate = creationDate ?? DateTime.UtcNow,
             AssignedAccount = account
         };
 
@@ -30,9 +30,11 @@ public class MailCopyIdentityExtensionsTests
         var inboxFolderId = Guid.NewGuid();
         var categoryFolderId = Guid.NewGuid();
 
+        var baseDate = DateTime.UtcNow;
+
         // The category copy is listed first and is newer, but the inbox copy is the preferred one.
-        var categoryCopy = BuildCopy("server-1", categoryFolderId, account, new DateTime(2026, 8, 15, 18, 0, 0, DateTimeKind.Utc));
-        var inboxCopy = BuildCopy("server-1", inboxFolderId, account, new DateTime(2026, 8, 15, 12, 0, 0, DateTimeKind.Utc));
+        var categoryCopy = BuildCopy("server-1", categoryFolderId, account, baseDate.AddHours(6));
+        var inboxCopy = BuildCopy("server-1", inboxFolderId, account, baseDate);
 
         var collapsed = new[] { categoryCopy, inboxCopy }
             .CollapseServerMessageDuplicates(null, mail => mail.FolderId == inboxFolderId)
@@ -80,8 +82,10 @@ public class MailCopyIdentityExtensionsTests
     {
         var account = new MailAccount { Id = Guid.NewGuid() };
 
-        var older = BuildCopy("server-1", Guid.NewGuid(), account, new DateTime(2026, 8, 15, 8, 0, 0, DateTimeKind.Utc));
-        var newer = BuildCopy("server-1", Guid.NewGuid(), account, new DateTime(2026, 8, 15, 20, 0, 0, DateTimeKind.Utc));
+        var baseDate = DateTime.UtcNow;
+
+        var older = BuildCopy("server-1", Guid.NewGuid(), account, baseDate.AddHours(-4));
+        var newer = BuildCopy("server-1", Guid.NewGuid(), account, baseDate.AddHours(8));
 
         var collapsed = new[] { older, newer }
             .CollapseServerMessageDuplicates(null, _ => false)

--- a/tests/Wino.Core.Tests/Services/MailCopyIdentityExtensionsTests.cs
+++ b/tests/Wino.Core.Tests/Services/MailCopyIdentityExtensionsTests.cs
@@ -1,0 +1,138 @@
+using FluentAssertions;
+using Wino.Core.Domain.Entities.Mail;
+using Wino.Core.Domain.Entities.Shared;
+using Wino.Core.Domain.Extensions;
+using Xunit;
+
+namespace Wino.Core.Tests.Services;
+
+public class MailCopyIdentityExtensionsTests
+{
+    private static MailCopy BuildCopy(
+        string serverId,
+        Guid folderId,
+        MailAccount? account = null,
+        DateTime? creationDate = null)
+        => new()
+        {
+            UniqueId = Guid.NewGuid(),
+            Id = serverId,
+            FolderId = folderId,
+            ThreadId = "thread-1",
+            CreationDate = creationDate ?? new DateTime(2026, 8, 15, 12, 0, 0, DateTimeKind.Utc),
+            AssignedAccount = account
+        };
+
+    [Fact]
+    public void CollapseServerMessageDuplicates_PrefersPreferredCopyRegardlessOfInputOrder()
+    {
+        var account = new MailAccount { Id = Guid.NewGuid() };
+        var inboxFolderId = Guid.NewGuid();
+        var categoryFolderId = Guid.NewGuid();
+
+        // The category copy is listed first and is newer, but the inbox copy is the preferred one.
+        var categoryCopy = BuildCopy("server-1", categoryFolderId, account, new DateTime(2026, 8, 15, 18, 0, 0, DateTimeKind.Utc));
+        var inboxCopy = BuildCopy("server-1", inboxFolderId, account, new DateTime(2026, 8, 15, 12, 0, 0, DateTimeKind.Utc));
+
+        var collapsed = new[] { categoryCopy, inboxCopy }
+            .CollapseServerMessageDuplicates(null, mail => mail.FolderId == inboxFolderId)
+            .ToList();
+
+        collapsed.Should().ContainSingle();
+        collapsed[0].UniqueId.Should().Be(inboxCopy.UniqueId);
+    }
+
+    [Fact]
+    public void CollapseServerMessageDuplicates_KeepsRowsFromDifferentAccounts()
+    {
+        var firstAccount = new MailAccount { Id = Guid.NewGuid() };
+        var secondAccount = new MailAccount { Id = Guid.NewGuid() };
+
+        var collapsed = new[]
+        {
+            BuildCopy("shared-server-id", Guid.NewGuid(), firstAccount),
+            BuildCopy("shared-server-id", Guid.NewGuid(), secondAccount)
+        }
+        .CollapseServerMessageDuplicates(null, _ => false)
+        .ToList();
+
+        collapsed.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void CollapseServerMessageDuplicates_TreatsRowsWithoutServerIdAsDistinct()
+    {
+        var account = new MailAccount { Id = Guid.NewGuid() };
+
+        var collapsed = new[]
+        {
+            BuildCopy(string.Empty, Guid.NewGuid(), account),
+            BuildCopy(null!, Guid.NewGuid(), account)
+        }
+        .CollapseServerMessageDuplicates(null, _ => false)
+        .ToList();
+
+        collapsed.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void CollapseServerMessageDuplicates_FallsBackToNewestWhenNoCopyIsPreferred()
+    {
+        var account = new MailAccount { Id = Guid.NewGuid() };
+
+        var older = BuildCopy("server-1", Guid.NewGuid(), account, new DateTime(2026, 8, 15, 8, 0, 0, DateTimeKind.Utc));
+        var newer = BuildCopy("server-1", Guid.NewGuid(), account, new DateTime(2026, 8, 15, 20, 0, 0, DateTimeKind.Utc));
+
+        var collapsed = new[] { older, newer }
+            .CollapseServerMessageDuplicates(null, _ => false)
+            .ToList();
+
+        collapsed.Should().ContainSingle();
+        collapsed[0].UniqueId.Should().Be(newer.UniqueId);
+    }
+
+    [Fact]
+    public void CollapseServerMessageDuplicates_GroupsUnhydratedCopiesThroughTheFolderMap()
+    {
+        var accountId = Guid.NewGuid();
+        var inboxFolderId = Guid.NewGuid();
+        var unreadFolderId = Guid.NewGuid();
+
+        var accountIdsByFolderId = new Dictionary<Guid, Guid>
+        {
+            [inboxFolderId] = accountId,
+            [unreadFolderId] = accountId
+        };
+
+        var collapsed = new[]
+        {
+            BuildCopy("server-1", unreadFolderId),
+            BuildCopy("server-1", inboxFolderId)
+        }
+        .CollapseServerMessageDuplicates(accountIdsByFolderId, mail => mail.FolderId == inboxFolderId)
+        .ToList();
+
+        collapsed.Should().ContainSingle();
+        collapsed[0].FolderId.Should().Be(inboxFolderId);
+    }
+
+    [Fact]
+    public void ResolveAccountId_PrefersAssignedAccountOverFolderMap()
+    {
+        var assignedAccountId = Guid.NewGuid();
+        var folderId = Guid.NewGuid();
+        var copy = BuildCopy("server-1", folderId, new MailAccount { Id = assignedAccountId });
+
+        var resolved = copy.ResolveAccountId(new Dictionary<Guid, Guid> { [folderId] = Guid.NewGuid() });
+
+        resolved.Should().Be(assignedAccountId);
+    }
+
+    [Fact]
+    public void ResolveServerMailId_WithoutServerId_FallsBackToUniqueId()
+    {
+        var copy = BuildCopy(string.Empty, Guid.NewGuid());
+
+        copy.ResolveServerMailId().Should().Be(copy.UniqueId.ToString("N"));
+    }
+}

--- a/tests/Wino.Core.Tests/Services/MailFetchingTests.cs
+++ b/tests/Wino.Core.Tests/Services/MailFetchingTests.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Collections.Concurrent;
 using FluentAssertions;
 using Moq;
@@ -114,6 +114,118 @@ public class MailFetchingTests : IAsyncLifetime
             "every returned mail must have its account and folder resolved");
         result.Count(m => m.ThreadId == threadA).Should().Be(3, "Thread A must be complete");
         result.Count(m => m.ThreadId == threadB).Should().Be(3, "Thread B must be complete");
+    }
+
+    // ── Correctness: Gmail label copies ────────────────────────────────────────
+
+    /// <summary>
+    /// Gmail stores one MailCopy row per label, all sharing the same server Id. Thread expansion
+    /// pulls every one of those rows for siblings outside the page, so they must be collapsed.
+    /// </summary>
+    [Fact]
+    public async Task FetchMailsAsync_WithThreadingEnabled_CollapsesGmailLabelCopiesOfSameServerMessage()
+    {
+        const int PageSize = 1;
+        var unreadFolder = await CreateFolderAsync(_testAccount, "Unread", "UNREAD", SpecialFolderType.Unread);
+        var categoryFolder = await CreateFolderAsync(_testAccount, "Personal", "CATEGORY_PERSONAL", SpecialFolderType.Personal);
+
+        var threadId = Guid.NewGuid().ToString();
+        var baseDate = DateTime.UtcNow;
+        var siblingServerId = Guid.NewGuid().ToString();
+
+        var mails = new List<MailCopy>
+        {
+            // Newest message - the only seed that fits in the page.
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-1), threadId: threadId),
+            // Older sibling, materialised once per Gmail label.
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-2), threadId: threadId, id: siblingServerId),
+            BuildMail(unreadFolder.Id, baseDate.AddSeconds(-2), threadId: threadId, id: siblingServerId),
+            BuildMail(categoryFolder.Id, baseDate.AddSeconds(-2), threadId: threadId, id: siblingServerId)
+        };
+        await _databaseService.Connection.InsertAllAsync(mails, typeof(MailCopy));
+
+        var result = await _mailService.FetchMailsAsync(BuildOptions([_inboxFolder], createThreads: true, take: PageSize));
+
+        result.Should().HaveCount(2,
+            "the three label rows of the older sibling represent a single server message");
+        result.Count(m => m.Id == siblingServerId).Should().Be(1,
+            "only one copy of a server message may be surfaced");
+    }
+
+    /// <summary>
+    /// The surviving copy must be the one in the folder being listed, because folder scoped
+    /// actions and the active-seed check target it. Insertion order and date must not win.
+    /// </summary>
+    [Fact]
+    public async Task FetchMailsAsync_WithThreadingEnabled_KeepsListedFolderCopyOfDuplicatedThreadSibling()
+    {
+        const int PageSize = 1;
+        var categoryFolder = await CreateFolderAsync(_testAccount, "Personal", "CATEGORY_PERSONAL", SpecialFolderType.Personal);
+
+        var threadId = Guid.NewGuid().ToString();
+        var baseDate = DateTime.UtcNow;
+        var siblingServerId = Guid.NewGuid().ToString();
+
+        var mails = new List<MailCopy>
+        {
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-1), threadId: threadId),
+            // Category copy is inserted first AND is newer, but the inbox copy must still win.
+            BuildMail(categoryFolder.Id, baseDate.AddSeconds(-2), threadId: threadId, id: siblingServerId),
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-3), threadId: threadId, id: siblingServerId)
+        };
+        await _databaseService.Connection.InsertAllAsync(mails, typeof(MailCopy));
+
+        var result = await _mailService.FetchMailsAsync(BuildOptions([_inboxFolder], createThreads: true, take: PageSize));
+
+        var sibling = result.Single(m => m.Id == siblingServerId);
+        sibling.FolderId.Should().Be(_inboxFolder.Id,
+            "the copy belonging to the listed folder must survive regardless of insertion order or date");
+    }
+
+    /// <summary>
+    /// Distinct server messages in one thread must never be merged by the collapse.
+    /// </summary>
+    [Fact]
+    public async Task FetchMailsAsync_WithThreadingEnabled_KeepsDistinctServerMessagesInSameThread()
+    {
+        const int PageSize = 1;
+        var threadId = Guid.NewGuid().ToString();
+        var baseDate = DateTime.UtcNow;
+
+        var mails = new List<MailCopy>
+        {
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-1), threadId: threadId),
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-2), threadId: threadId),
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-3), threadId: threadId)
+        };
+        await _databaseService.Connection.InsertAllAsync(mails, typeof(MailCopy));
+
+        var result = await _mailService.FetchMailsAsync(BuildOptions([_inboxFolder], createThreads: true, take: PageSize));
+
+        result.Should().HaveCount(3, "three different server messages must stay three rows");
+    }
+
+    /// <summary>
+    /// The collapse is gated on thread expansion actually running, so the non-threaded path
+    /// must keep returning every label row of the listed folder.
+    /// </summary>
+    [Fact]
+    public async Task FetchMailsAsync_WithThreadingDisabled_DoesNotCollapseLabelCopies()
+    {
+        var threadId = Guid.NewGuid().ToString();
+        var baseDate = DateTime.UtcNow;
+        var serverId = Guid.NewGuid().ToString();
+
+        var mails = new List<MailCopy>
+        {
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-1), threadId: threadId, id: serverId),
+            BuildMail(_inboxFolder.Id, baseDate.AddSeconds(-2), threadId: threadId, id: serverId)
+        };
+        await _databaseService.Connection.InsertAllAsync(mails, typeof(MailCopy));
+
+        var result = await _mailService.FetchMailsAsync(BuildOptions([_inboxFolder], createThreads: false));
+
+        result.Should().HaveCount(2, "collapsing must not happen when threading is disabled");
     }
 
     // ── Correctness: threading OFF ─────────────────────────────────────────────

--- a/tests/Wino.Core.Tests/Services/MailThreadingTests.cs
+++ b/tests/Wino.Core.Tests/Services/MailThreadingTests.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Mvvm.Messaging;
+﻿using CommunityToolkit.Mvvm.Messaging;
 using FluentAssertions;
 using MimeKit;
 using Moq;
@@ -480,6 +480,87 @@ public class MailThreadingTests : IAsyncLifetime
         }
     }
 
+    /// <summary>
+    /// Gmail fans a single server message into one package per label, and all of those rows are
+    /// inserted in one CreateMailsAsync call. That means the UI receives a single
+    /// BulkMailAddedMessage carrying every label row, not one MailAddedMessage per row.
+    ///
+    /// MailListPageViewModel.OnBulkMailAdded relies on this shape: it filters the whole batch
+    /// before adding anything, so it has to collapse the label rows itself. If the batching here
+    /// ever changes, that collapse silently stops being reachable - hence this test.
+    /// </summary>
+    [Fact]
+    public async Task CreateMailsAsync_ForGmailLabelCopies_ReportsSingleBulkAddWithAllLabelRows()
+    {
+        var gmailAccount = new MailAccount
+        {
+            Id = Guid.NewGuid(),
+            Name = "Gmail Test Account",
+            Address = "gmail@test.local",
+            SenderName = "Gmail User",
+            ProviderType = MailProviderType.Gmail
+        };
+        await _databaseService.Connection.InsertAsync(gmailAccount, typeof(MailAccount));
+
+        var labelIds = new[] { "UNREAD", "INBOX", "CATEGORY_PERSONAL" };
+        foreach (var labelId in labelIds)
+        {
+            await _databaseService.Connection.InsertAsync(new MailItemFolder
+            {
+                Id = Guid.NewGuid(),
+                MailAccountId = gmailAccount.Id,
+                FolderName = labelId,
+                RemoteFolderId = labelId,
+                SpecialFolderType = SpecialFolderType.Other,
+                IsSystemFolder = true,
+                IsSynchronizationEnabled = true
+            }, typeof(MailItemFolder));
+        }
+
+        // All label rows share the server id, thread id and file id, exactly as the synchronizer builds them.
+        var sharedServerId = "gmail-server-message-1";
+        var sharedFileId = Guid.NewGuid();
+        var packages = labelIds
+            .Select(labelId => new NewMailItemPackage(
+                new MailCopy
+                {
+                    UniqueId = Guid.NewGuid(),
+                    Id = sharedServerId,
+                    FileId = sharedFileId,
+                    ThreadId = "gmail-thread-1",
+                    Subject = "Label fan-out",
+                    FromAddress = "sender@example.com",
+                    FromName = "Sender",
+                    CreationDate = DateTime.UtcNow
+                },
+                Mime: null,
+                AssignedRemoteFolderId: labelId))
+            .ToList();
+
+        var bulkRecipient = new BulkMailAddRecipient();
+        var singleRecipient = new MailAddRecipient();
+        WeakReferenceMessenger.Default.Register<BulkMailAddedMessage>(bulkRecipient);
+        WeakReferenceMessenger.Default.Register<MailAddedMessage>(singleRecipient);
+
+        try
+        {
+            await _mailService.CreateMailsAsync(gmailAccount.Id, packages);
+
+            singleRecipient.Added.Should().BeEmpty(
+                "label rows are inserted together, so they are never reported one by one");
+            bulkRecipient.Added.Should().ContainSingle(
+                "the whole label fan-out arrives as one batch");
+            bulkRecipient.Added[0].AddedMails.Should().HaveCount(labelIds.Length);
+            bulkRecipient.Added[0].AddedMails.Should().OnlyContain(mail => mail.Id == sharedServerId,
+                "every row in the batch is the same server message");
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.Unregister<BulkMailAddedMessage>(bulkRecipient);
+            WeakReferenceMessenger.Default.Unregister<MailAddedMessage>(singleRecipient);
+        }
+    }
+
     private static MimeMessage CreateReferencedMimeMessage(string subject, string? messageId = null)
     {
         var message = new MimeMessage();
@@ -508,6 +589,13 @@ public class MailThreadingTests : IAsyncLifetime
         public List<MailAddedMessage> Added { get; } = [];
 
         public void Receive(MailAddedMessage message) => Added.Add(message);
+    }
+
+    internal sealed class BulkMailAddRecipient : IRecipient<BulkMailAddedMessage>
+    {
+        public List<BulkMailAddedMessage> Added { get; } = [];
+
+        public void Receive(BulkMailAddedMessage message) => Added.Add(message);
     }
 
     internal sealed class MailReadStatusRecipient : IRecipient<MailReadStatusChanged>, IRecipient<BulkMailReadStatusChanged>

--- a/tests/Wino.Mail.ViewModels.Tests/Collections/MailListStoreTests.cs
+++ b/tests/Wino.Mail.ViewModels.Tests/Collections/MailListStoreTests.cs
@@ -1,10 +1,11 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Wino.Core.Domain.Entities.Mail;
+using Wino.Core.Domain.Entities.Shared;
 using Wino.Core.Domain.Enums;
 using Wino.Core.Domain.Interfaces;
 using Wino.Core.Domain.Models.MailItem;
@@ -170,10 +171,72 @@ public sealed class MailListStoreTests
         store.ItemIds.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task ContainsOtherServerMailCopy_WhenLabelSiblingIsListed_ReturnsTrue()
+    {
+        var store = CreateStore();
+        var account = new MailAccount { Id = Guid.NewGuid() };
+        var serverId = Guid.NewGuid().ToString("N");
+
+        var inboxCopy = CreateMailCopy("thread-1", serverId, account);
+        await store.AddAsync(inboxCopy);
+
+        // Same server message, different Gmail label folder, therefore a different UniqueId.
+        var unreadCopy = CreateMailCopy("thread-1", serverId, account);
+
+        store.ContainsOtherServerMailCopy(unreadCopy).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ContainsOtherServerMailCopy_ForSameUniqueId_ReturnsFalse()
+    {
+        var store = CreateStore();
+        var account = new MailAccount { Id = Guid.NewGuid() };
+
+        var copy = CreateMailCopy("thread-1", Guid.NewGuid().ToString("N"), account);
+        await store.AddAsync(copy);
+
+        // Re-adds and updates of an already listed row must never be suppressed.
+        store.ContainsOtherServerMailCopy(CloneMailCopy(copy)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ContainsOtherServerMailCopy_ForDifferentAccountWithSameServerId_ReturnsFalse()
+    {
+        var store = CreateStore();
+        var serverId = Guid.NewGuid().ToString("N");
+
+        await store.AddAsync(CreateMailCopy("thread-1", serverId, new MailAccount { Id = Guid.NewGuid() }));
+
+        var otherAccountCopy = CreateMailCopy("thread-1", serverId, new MailAccount { Id = Guid.NewGuid() });
+
+        store.ContainsOtherServerMailCopy(otherAccountCopy).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ContainsOtherServerMailCopy_WhenServerIdIsMissing_ReturnsFalse()
+    {
+        var store = CreateStore();
+        var account = new MailAccount { Id = Guid.NewGuid() };
+
+        await store.AddAsync(CreateMailCopy("thread-1", string.Empty, account));
+
+        // Local drafts have no server id yet and must stay visible.
+        store.ContainsOtherServerMailCopy(CreateMailCopy("thread-1", string.Empty, account)).Should().BeFalse();
+    }
+
     private static MailListStore CreateStore() => new()
     {
         CoreDispatcher = new ImmediateDispatcher(),
     };
+
+    private static MailCopy CreateMailCopy(string threadId, string serverId, MailAccount account)
+    {
+        var copy = CreateMailCopy(threadId);
+        copy.Id = serverId;
+        copy.AssignedAccount = account;
+        return copy;
+    }
 
     private static MailCopy CreateMailCopy(string threadId) => new()
     {


### PR DESCRIPTION
Fixes #916.

## The problem

On a Gmail account with conversation threading turned on, a single incoming email shows up two, three or four times inside the same conversation group. Restarting Wino, or switching to another folder and back, makes the duplicates disappear.

## Why

Gmail does not really have folders. It has labels, and one message usually carries several of them at once, for example Inbox, Unread, Important and a category label such as Personal.

Wino turns every Gmail label into a local folder. Because a message must be visible in each of its folders, the Gmail sync stores one row per label. So a single ordinary email is saved as three or four rows in the database. All of those rows describe the same server message and carry the same message id and the same conversation id. Only their folder differs. This is intentional, and it is what lets a Gmail message appear in the Inbox and under a user label at the same time.

The problem is that the code which adds newly arrived mail to the list on screen never knew about this. It decided whether to show an incoming row by asking one question: is this row part of a conversation that is already visible? Every one of the label rows answered yes, because they all share the same conversation id. So all of them were added, and the conversation group ended up showing the same email several times.

There are two ways this happens. When the label rows arrive together as one batch, which is the normal case for a reply to a conversation you are already looking at, all of them pass the check at once. When they arrive one at a time, which happens when labels change on an existing message, each new one is waved in because the earlier one is already on screen.

Outlook and IMAP accounts are not affected. Outlook stores one row per message, and IMAP already gives each folder copy its own distinct id.

## What

The fix teaches the app that several database rows can be the same real message, and that only one of them may ever be shown.

A small shared helper answers two questions: do these two rows represent the same server message on the same account, and if so, which one should survive. The surviving copy is always the one belonging to the folder you are currently looking at. That matters, because actions like archive and move act on a specific folder, and because the list uses that copy to decide whether the conversation still belongs in the current view. Gmail does not promise to list Inbox first, so simply keeping whichever row arrived first would often keep the wrong one.

That helper is then used in three places. Two of them cover live mail arriving while the app is open, one for rows that arrive together in a batch and one for rows that trickle in separately. The third covers loading a conversation from the database, which fixes the long conversation case.

The same helper also replaces a nearly identical piece of logic that already existed for online search, so there is now one implementation instead of two.

## Files modified

- New file: src/Wino.Core.Domain/Extensions/MailCopyIdentityExtensions.cs: Holds the shared logic for recognising that two rows are the same server message, and for choosing which copy to keep.

- src/Wino.Services/MailService.cs: Now uses the shared helper instead of its own private copy of that logic, and removes duplicate rows when it loads the rest of a conversation from the database.

- src/Wino.Mail.ViewModels/Collections/MailListStore.cs: Gains a way to ask whether another copy of the same server message is already showing in the list.

- src/Wino.Mail.ViewModels/MailListPageViewModel.cs: Uses that new question before letting an arriving mail into the list, and collapses duplicates when a group of rows arrives together.

## One known limitation

When the copy being shown is removed, for example by archiving it, the hidden copies do not come back. This is the right behaviour in the common case, because archiving from the Inbox should not leave the message sitting in the Inbox list. The one visible difference is that archiving a single message inside an open conversation removes it, where reloading the folder would still show it. That difference already exists today for other reasons, and it corrects itself as soon as the folder is reloaded.

## Testing

- Use a Gmail account with conversation threading turned on, with the Inbox open and a conversation visible on screen.
- Receive a reply to that conversation. The group should gain exactly one new message.
- Archive that message. It should leave the list, which confirms the copy being shown is the Inbox one.
- Open a long conversation whose older replies are further down than the current page. Each message should appear once.
- Turn threading off and on again. The list should look the same as it does after a restart.
