### PR TITLE
New mail does not appear at the top of the list

### DIFF
--- a/src/Wino.Core/Extensions/OutlookIntegratorExtensions.cs
+++ b/src/Wino.Core/Extensions/OutlookIntegratorExtensions.cs
@@ -61,7 +61,7 @@ public static class OutlookIntegratorExtensions
             IsRead = GetIsRead(outlookMessage),
             IsReadReceiptRequested = GetIsReadReceiptRequested(outlookMessage),
             IsDraft = isDraft,
-            CreationDate = outlookMessage.ReceivedDateTime.GetValueOrDefault().DateTime,
+            CreationDate = outlookMessage.ReceivedDateTime.GetValueOrDefault().UtcDateTime,
             HasAttachments = outlookMessage.HasAttachments.GetValueOrDefault(),
             PreviewText = outlookMessage.BodyPreview,
             Id = outlookMessage.Id,

--- a/src/Wino.Mail.ViewModels/Data/MailItemViewModel.cs
+++ b/src/Wino.Mail.ViewModels/Data/MailItemViewModel.cs
@@ -101,7 +101,12 @@ public partial class MailItemViewModel : ObservableRecipient, IMailListItem, IMa
 
     public string? ThreadKey => ThreadId;
 
-    public DateTimeOffset DateSortKey => new(CreationDate);
+    // CreationDate is stored as UTC everywhere in the mail pipeline, but sqlite hands it back with
+    // DateTimeKind.Unspecified while a freshly synced copy still carries DateTimeKind.Utc.
+    // new DateTimeOffset(DateTime) assumes Unspecified means local, so without pinning the kind the
+    // two paths produce instants that differ by the local UTC offset and sort against each other.
+    // The display layer already reads it as UTC via DateTime.ToLocalTime, so this matches it.
+    public DateTimeOffset DateSortKey => new(DateTime.SpecifyKind(CreationDate, DateTimeKind.Utc));
 
     public string NameSortKey => SortingName ?? string.Empty;
 

--- a/tests/Wino.Mail.Controls.Tests/MailListCollectionTests.cs
+++ b/tests/Wino.Mail.Controls.Tests/MailListCollectionTests.cs
@@ -237,6 +237,24 @@ public sealed class MailListCollectionTests
             new MailListProjectionGroupKey(true, null));
     }
 
+    [Fact]
+    public void Projection_SortsNewestItemToTheTop_WhenItIsAppendedLast()
+    {
+        var collection = new MailListCollection<TestItem>();
+        var older = new TestItem("older", date: DateTimeOffset.Now.AddHours(-3));
+        var oldest = new TestItem("oldest", date: DateTimeOffset.Now.AddHours(-6));
+        collection.AddRange([older, oldest]);
+
+        using var projection = new MailListProjection(collection);
+
+        // The flat collection only ever appends, so a live arrival lands at the end.
+        // The projection is what has to put it back on top.
+        var newest = new TestItem("newest", date: DateTimeOffset.Now);
+        collection.TryAdd(newest);
+
+        projection.Rows.First().SourceItem.StableId.Should().Be(newest.StableId);
+    }
+
     private sealed class TestItem : IMailListSourceItem
     {
         private bool _isPinned;

--- a/tests/Wino.Mail.ViewModels.Tests/Data/MailItemViewModelUpdateTests.cs
+++ b/tests/Wino.Mail.ViewModels.Tests/Data/MailItemViewModelUpdateTests.cs
@@ -129,23 +129,43 @@ public class MailItemViewModelUpdateTests
     [Fact]
     public void DateSortKey_ForUnspecifiedKind_IsInterpretedAsUtc()
     {
-        var creationDate = new DateTime(2026, 8, 15, 12, 0, 0, DateTimeKind.Unspecified);
-        var sut = new MailItemViewModel(CreateMailCopy("thread-1", creationDate));
+        foreach (var creationDate in CreateStoredCreationDates())
+        {
+            var sut = new MailItemViewModel(CreateMailCopy("thread-1", creationDate));
 
-        sut.DateSortKey.UtcDateTime.Should().Be(DateTime.SpecifyKind(creationDate, DateTimeKind.Utc));
+            sut.DateSortKey.UtcDateTime.Should().Be(DateTime.SpecifyKind(creationDate, DateTimeKind.Utc));
+        }
     }
 
     [Fact]
     public void DateSortKey_ForUnspecifiedAndUtcKind_ProducesTheSameInstant()
     {
-        var ticks = new DateTime(2026, 8, 15, 12, 0, 0, DateTimeKind.Unspecified);
+        foreach (var creationDate in CreateStoredCreationDates())
+        {
+            var fromDatabase = new MailItemViewModel(CreateMailCopy("thread-1", creationDate));
+            var fromSynchronizer = new MailItemViewModel(
+                CreateMailCopy("thread-1", DateTime.SpecifyKind(creationDate, DateTimeKind.Utc)));
 
-        var fromDatabase = new MailItemViewModel(CreateMailCopy("thread-1", ticks));
-        var fromSynchronizer = new MailItemViewModel(
-            CreateMailCopy("thread-1", DateTime.SpecifyKind(ticks, DateTimeKind.Utc)));
+            fromDatabase.DateSortKey.Should().Be(fromSynchronizer.DateSortKey,
+                "a mail loaded from the database and the same mail arriving live must sort identically");
+        }
+    }
 
-        fromDatabase.DateSortKey.Should().Be(fromSynchronizer.DateSortKey,
-            "a mail loaded from the database and the same mail arriving live must sort identically");
+    /// <summary>
+    /// Current UTC instants with their kind stripped, which is what sqlite hands back on a folder load.
+    ///
+    /// Two samples six months apart, because new DateTimeOffset(DateTime) resolves the offset for the
+    /// date value itself. A zone that sits at UTC+0 for part of the year, such as the UK, would give
+    /// a zero offset for a single sample taken in winter, and then this assertion holds whether or not
+    /// the sort key is correct. Sampling both halves of the year guarantees at least one non zero
+    /// offset in any zone that ever has one. Nothing can catch it in a zone that is UTC all year.
+    /// </summary>
+    private static IEnumerable<DateTime> CreateStoredCreationDates()
+    {
+        var now = DateTime.UtcNow;
+
+        yield return DateTime.SpecifyKind(now, DateTimeKind.Unspecified);
+        yield return DateTime.SpecifyKind(now.AddMonths(6), DateTimeKind.Unspecified);
     }
 
     private static MailCopy CreateMailCopy(string threadId, DateTime creationDate)

--- a/tests/Wino.Mail.ViewModels.Tests/Data/MailItemViewModelUpdateTests.cs
+++ b/tests/Wino.Mail.ViewModels.Tests/Data/MailItemViewModelUpdateTests.cs
@@ -116,6 +116,38 @@ public class MailItemViewModelUpdateTests
         raisedProperties.Should().Contain(nameof(MailItemViewModel.IsRead));
     }
 
+    /// <summary>
+    /// CreationDate is stored as UTC everywhere, but the two ways a mail reaches the list disagree on
+    /// its DateTimeKind: sqlite returns Unspecified on a folder load, while a freshly synced copy is
+    /// still Utc. new DateTimeOffset(DateTime) reads Unspecified as local time, so the sort key used
+    /// to differ by the local UTC offset between those two paths and a newly arrived mail sorted into
+    /// the middle of the list until the folder was reloaded.
+    ///
+    /// Note this assertion can only fail on a machine that is not at UTC, because at UTC the two
+    /// interpretations coincide. Running the suite in a non-UTC zone is what actually protects this.
+    /// </summary>
+    [Fact]
+    public void DateSortKey_ForUnspecifiedKind_IsInterpretedAsUtc()
+    {
+        var creationDate = new DateTime(2026, 8, 15, 12, 0, 0, DateTimeKind.Unspecified);
+        var sut = new MailItemViewModel(CreateMailCopy("thread-1", creationDate));
+
+        sut.DateSortKey.UtcDateTime.Should().Be(DateTime.SpecifyKind(creationDate, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void DateSortKey_ForUnspecifiedAndUtcKind_ProducesTheSameInstant()
+    {
+        var ticks = new DateTime(2026, 8, 15, 12, 0, 0, DateTimeKind.Unspecified);
+
+        var fromDatabase = new MailItemViewModel(CreateMailCopy("thread-1", ticks));
+        var fromSynchronizer = new MailItemViewModel(
+            CreateMailCopy("thread-1", DateTime.SpecifyKind(ticks, DateTimeKind.Utc)));
+
+        fromDatabase.DateSortKey.Should().Be(fromSynchronizer.DateSortKey,
+            "a mail loaded from the database and the same mail arriving live must sort identically");
+    }
+
     private static MailCopy CreateMailCopy(string threadId, DateTime creationDate)
         => new()
         {


### PR DESCRIPTION
Fixes #1023.

## Why

When a new email arrives while Wino is open it does not go to the top of the list. It lands somewhere in the middle. The cause is that the date the list sorts on is misread. Mail loaded from the database comes back with no marker saying whether its date is UTC or local time and the sorting code guesses local, while mail that has just arrived skips the database and still carries a proper UTC marker. Both hold the same real time, so a new message gets compared against the older ones as if it were off by exactly your time zone offset.

I am at UTC minus three, so older mail looks three hours newer than it is and anything arriving now falls below the last few hours of mail.

Gmail and IMAP are affected, Outlook is not.

## What

The sort key now states plainly that the stored date is UTC instead of leaving it to be guessed, which is what the rest of the app already assumes since every date shown to the user is converted that way. A message loaded from the database and the same message arriving live now produce the same point in time, and the day headings are corrected by the same change because the conversion to local time finally starts from the right value.

- src/Wino.Mail.ViewModels/Data/MailItemViewModel.cs pins the date to UTC before building the sort key, with a comment explaining why, since this is an easy thing to undo by accident.

- src/Wino.Core/Extensions/OutlookIntegratorExtensions.cs reads the Outlook date as UTC. Nothing changes in practice because Graph already returns UTC, but it removes the last place that produced a date without a marker.

Nothing was changed for messages that share an identical date. Those still fall back to arrival order, and fixing it breaks an existing test that asserts the current behaviour on purpose, so it belongs in its own change.

## Testing

- Note which message is currently at the top of your inbox.
- Leave Wino open and send yourself a message, or wait for one to arrive.
- It should appear at the top of the list straight away, without switching folders or restarting.
- Check that the time shown on it matches your clock.
