### PR TITLE
fix(compose): let attachment rows expand for long filenames

### DIFF
--- a/Wino.Mail.WinUI/Views/Mail/ComposePage.xaml
+++ b/Wino.Mail.WinUI/Views/Mail/ComposePage.xaml
@@ -68,7 +68,7 @@
         <!--  Margin -8 0 is used to remove the padding from the ListViewItem  -->
         <DataTemplate x:Key="ComposerFileAttachmentTemplate" x:DataType="data:MailAttachmentViewModel">
             <Grid
-                Height="50"
+                MinHeight="50"
                 Margin="0"
                 Padding="0"
                 Background="Transparent"
@@ -91,7 +91,7 @@
                     <ToolTip Content="{x:Bind FileName}" />
                 </ToolTipService.ToolTip>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="36" />
+                    <ColumnDefinition Width="40" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
@@ -105,7 +105,7 @@
                 <!--  Name && Size  -->
                 <Grid
                     Grid.Column="1"
-                    MaxWidth="200"
+                    HorizontalAlignment="Stretch"
                     VerticalAlignment="Center">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -114,14 +114,16 @@
 
                     <TextBlock
                 Style="{StaticResource CaptionTextBlockStyle}"
+                        HorizontalAlignment="Center"
                         MaxLines="2"
                         Text="{x:Bind FileName}"
+                        TextAlignment="Center"
                         TextTrimming="CharacterEllipsis" />
 
                     <TextBlock
                 Style="{StaticResource CaptionTextBlockStyle}"
                         Grid.Row="1"
-                        HorizontalAlignment="Right"
+                        HorizontalAlignment="Center"
                         VerticalAlignment="Bottom"
                         Foreground="Gray"
                         Text="{x:Bind ReadableSize}" />


### PR DESCRIPTION
## Summary

Resolves the rendering issue reported in #1000 where attachment rows in the compose window were visually cut off and difficult to read.

## What was happening

The `ComposerFileAttachmentTemplate` in `Wino.Mail.WinUI/Views/Mail/ComposePage.xaml` declared a fixed `Height="50"` on the row Grid while also setting `MaxLines="2"` on the filename `TextBlock`. When an attachment name wrapped to a second line, the row stayed at 50px and clipped the second line of text. The inner name-and-size grid was also capped at `MaxWidth="200"` and right-aligned, which compounded the "too narrow, cut off" appearance in narrow compose panes.

## Fix

Single-file change to `Wino.Mail.WinUI/Views/Mail/ComposePage.xaml`:

- Replace `Height="50"` with `MinHeight="50"` so the row auto-grows when the filename wraps while keeping a consistent baseline height for short names.
- Widen the icon column from 36 to 40 to match the read-only `FileAttachmentTemplate` in `MailRenderingPage.xaml`.
- Drop `MaxWidth="200"` and stretch the name/size grid horizontally so the row fills the available compose area instead of being clamped.
- Center the filename and readable size horizontally and set `TextAlignment="Center"` on the filename for clearer presentation.

## Notes

- The attachment file-type icon was already implemented via `FileTypeIconSelector` (see `Wino.Mail.WinUI/Styles/IconTemplates.xaml`) and is rendered through the `AttachmentType` property on `MailAttachmentViewModel`. The icon column width change makes the existing icon template a touch more legible.
- Followed the project Settings.XamlStyler attribute ordering and the existing surrounding indentation style.
- No behavioural changes outside the attachment row template.

Closes #1000